### PR TITLE
Fix build errors

### DIFF
--- a/src/Platform_unix.cpp
+++ b/src/Platform_unix.cpp
@@ -36,6 +36,7 @@
 #include <string.h>
 #include <sys/resource.h>
 #include <uv.h>
+#include <stdio.h>
 
 
 #include "Platform.h"

--- a/src/workers/Hashrate.cpp
+++ b/src/workers/Hashrate.cpp
@@ -25,6 +25,7 @@
 #include <chrono>
 #include <math.h>
 #include <memory.h>
+#include <stdio.h>
 
 #include "log/Log.h"
 #include "Options.h"


### PR DESCRIPTION
> /home/mine/xmrig-amd/src/workers/Hashrate.cpp: In function ‘const char* format(double, char*, size_t)’:
/home/mine/xmrig-amd/src/workers/Hashrate.cpp:37:40: error: ‘snprintf’ was not declared in this scope
         snprintf(buf, size, "%03.1f", h);
                                        ^
CMakeFiles/xmrig-amd.dir/build.make:629: recipe for target 'CMakeFiles/xmrig-amd.dir/src/workers/Hashrate.cpp.o' failed