### PR TITLE
Changes for the Monero v1 PoW

### DIFF
--- a/src/amd/opencl/cryptonight.cl
+++ b/src/amd/opencl/cryptonight.cl
@@ -84,6 +84,31 @@ XMRIG_INCLUDE_BLAKE256
 //#include "opencl/groestl256.cl"
 XMRIG_INCLUDE_GROESTL256
 
+#define VARIANT1_1(p) \
+        do if (MONERO && version > 6) \
+        { \
+                uint table = 0x75310U; \
+                uint index = (((p).s2 >> 26) & 12) | (((p).s2 >> 23) & 2); \
+                (p).s2 ^= ((table >> index) & 0x30U) << 24; \
+        } while (0)
+
+#define VARIANT1_2(p) \
+        do if (MONERO && version > 6) \
+        { \
+                ((uint2 *)&(p))[0] ^= tweak1_2; \
+        } while (0)
+
+#define VARIANT1_INIT() \
+        uint2 tweak1_2; \
+        do if (MONERO && version > 6) \
+        { \
+                tweak1_2 = as_uint2(input[4]); \
+                tweak1_2.s0 >>= 24; \
+                tweak1_2.s0 |= tweak1_2.s1 << 8; \
+                tweak1_2.s1 = get_global_id(0); \
+                tweak1_2 ^= as_uint2(states[24]); \
+        } while(0)
+
 static const __constant ulong keccakf_rndc[24] = 
 {
     0x0000000000000001, 0x0000000000008082, 0x800000000000808a,
@@ -495,7 +520,7 @@ __kernel void cn0(__global ulong *input, __global uint4 *Scratchpad, __global ul
 }
 
 __attribute__((reqd_work_group_size(WORKSIZE, 1, 1)))
-__kernel void cn1(__global uint4 *Scratchpad, __global ulong *states, ulong Threads)
+__kernel void cn1(__global uint4 *Scratchpad, __global ulong *states, ulong Threads, uint version, __global ulong *input)
 {
 	ulong a[2], b[2];
 	__local uint AES0[256], AES1[256], AES2[256], AES3[256];
@@ -531,6 +556,8 @@ __kernel void cn1(__global uint4 *Scratchpad, __global ulong *states, ulong Thre
 
 	mem_fence(CLK_LOCAL_MEM_FENCE);
 
+	VARIANT1_INIT();
+
 	// do not use early return here
 	if(gIdx < Threads)
 	{
@@ -541,9 +568,11 @@ __kernel void cn1(__global uint4 *Scratchpad, __global ulong *states, ulong Thre
 
 			((uint4 *)c)[0] = Scratchpad[IDX((a[0] & MASK) >> 4)];
 			((uint4 *)c)[0] = AES_Round(AES0, AES1, AES2, AES3, ((uint4 *)c)[0], ((uint4 *)a)[0]);
-			//b_x ^= ((uint4 *)c)[0];
 
-			Scratchpad[IDX((a[0] & MASK) >> 4)] = b_x ^ ((uint4 *)c)[0];
+			b_x ^= ((uint4 *)c)[0];
+			VARIANT1_1(b_x);
+
+			Scratchpad[IDX((a[0] & MASK) >> 4)] = b_x;
 
 			uint4 tmp;
 			tmp = Scratchpad[IDX((c[0] & MASK) >> 4)];
@@ -551,7 +580,9 @@ __kernel void cn1(__global uint4 *Scratchpad, __global ulong *states, ulong Thre
 			a[1] += c[0] * as_ulong2(tmp).s0;
 			a[0] += mul_hi(c[0], as_ulong2(tmp).s0);
 
+			VARIANT1_2(a[1]);
 			Scratchpad[IDX((c[0] & MASK) >> 4)] = ((uint4 *)a)[0];
+			VARIANT1_2(a[1]);
 
 			((uint4 *)a)[0] ^= tmp;
 

--- a/src/crypto/CryptoNight.cpp
+++ b/src/crypto/CryptoNight.cpp
@@ -30,31 +30,31 @@
 #include "Options.h"
 
 
-void (*cryptonight_hash_ctx)(const void *input, size_t size, void *output, cryptonight_ctx *ctx) = nullptr;
+bool (*cryptonight_hash_ctx)(const void *input, size_t size, void *output, cryptonight_ctx *ctx, uint8_t version) = nullptr;
 
 
-static void cryptonight_av1_aesni(const void *input, size_t size, void *output, struct cryptonight_ctx *ctx) {
-    cryptonight_hash<0x80000, MEMORY, 0x1FFFF0, false>(input, size, output, ctx);
+static bool cryptonight_av1_aesni(const void *input, size_t size, void *output, struct cryptonight_ctx *ctx, uint8_t version) {
+    return cryptonight_hash<0x80000, MEMORY, 0x1FFFF0, false, true>(input, size, output, ctx, version);
 }
 
 
-static void cryptonight_av3_softaes(const void *input, size_t size, void *output, cryptonight_ctx *ctx) {
-    cryptonight_hash<0x80000, MEMORY, 0x1FFFF0, true>(input, size, output, ctx);
+static bool cryptonight_av3_softaes(const void *input, size_t size, void *output, cryptonight_ctx *ctx, uint8_t version) {
+    return cryptonight_hash<0x80000, MEMORY, 0x1FFFF0, true, true>(input, size, output, ctx, version);
 }
 
 
 #ifndef XMRIG_NO_AEON
-static void cryptonight_lite_av1_aesni(const void *input, size_t size, void *output, cryptonight_ctx *ctx) {
-    cryptonight_hash<0x40000, MEMORY_LITE, 0xFFFF0, false>(input, size, output, ctx);
+static bool cryptonight_lite_av1_aesni(const void *input, size_t size, void *output, cryptonight_ctx *ctx, uint8_t version) {
+    return cryptonight_hash<0x40000, MEMORY_LITE, 0xFFFF0, false, false>(input, size, output, ctx, version);
 }
 
 
-static void cryptonight_lite_av3_softaes(const void *input, size_t size, void *output, cryptonight_ctx *ctx) {
-    cryptonight_hash<0x40000, MEMORY_LITE, 0xFFFF0, true>(input, size, output, ctx);
+static bool cryptonight_lite_av3_softaes(const void *input, size_t size, void *output, cryptonight_ctx *ctx, uint8_t version) {
+    return cryptonight_hash<0x40000, MEMORY_LITE, 0xFFFF0, true, false>(input, size, output, ctx, version);
 }
 
 
-void (*cryptonight_variations[8])(const void *input, size_t size, void *output, cryptonight_ctx *ctx) = {
+bool (*cryptonight_variations[8])(const void *input, size_t size, void *output, cryptonight_ctx *ctx, uint8_t version) = {
             cryptonight_av1_aesni,
             nullptr,
             cryptonight_av3_softaes,
@@ -65,7 +65,7 @@ void (*cryptonight_variations[8])(const void *input, size_t size, void *output, 
             nullptr
         };
 #else
-void (*cryptonight_variations[4])(const void *input, size_t size, void *output, cryptonight_ctx *ctx) = {
+bool (*cryptonight_variations[4])(const void *input, size_t size, void *output, cryptonight_ctx *ctx, uint8_t version) = {
             cryptonight_av1_aesni,
             nullptr,
             cryptonight_av3_softaes,
@@ -76,9 +76,9 @@ void (*cryptonight_variations[4])(const void *input, size_t size, void *output, 
 
 bool CryptoNight::hash(const Job &job, JobResult &result, cryptonight_ctx *ctx)
 {
-    cryptonight_hash_ctx(job.blob(), job.size(), result.result, ctx);
+    const bool rc = cryptonight_hash_ctx(job.blob(), job.size(), result.result, ctx, job.version());
 
-    return *reinterpret_cast<uint64_t*>(result.result + 24) < job.target();
+    return rc && *reinterpret_cast<uint64_t*>(result.result + 24) < job.target();
 }
 
 
@@ -100,9 +100,9 @@ bool CryptoNight::init(int algo, int variant)
 }
 
 
-void CryptoNight::hash(const uint8_t *input, size_t size, uint8_t *output, cryptonight_ctx *ctx)
+bool CryptoNight::hash(const uint8_t *input, size_t size, uint8_t *output, cryptonight_ctx *ctx, uint8_t version)
 {
-    cryptonight_hash_ctx(input, size, output, ctx);
+    return cryptonight_hash_ctx(input, size, output, ctx, version);
 }
 
 
@@ -115,13 +115,13 @@ bool CryptoNight::selfTest(int algo) {
 
     cryptonight_ctx *ctx = static_cast<cryptonight_ctx*>(_mm_malloc(sizeof(struct cryptonight_ctx), 16));
 
-    cryptonight_hash_ctx(test_input, 76, output, ctx);
+    const bool rc = cryptonight_hash_ctx(test_input, 76, output, ctx, 0);
 
     _mm_free(ctx);
 
 #   ifdef XMRIG_NO_AEON
-    return memcmp(output, test_output0, 32) == 0;
+    return rc && memcmp(output, test_output0, 32) == 0;
 #   else
-    return memcmp(output, algo == Options::ALGO_CRYPTONIGHT_LITE ? test_output1 : test_output0, 32) == 0;
+    return rc && memcmp(output, algo == Options::ALGO_CRYPTONIGHT_LITE ? test_output1 : test_output0, 32) == 0;
 #   endif
 }

--- a/src/crypto/CryptoNight.h
+++ b/src/crypto/CryptoNight.h
@@ -53,7 +53,7 @@ class CryptoNight
 public:
     static bool hash(const Job &job, JobResult &result, cryptonight_ctx *ctx);
     static bool init(int algo, int variant);
-    static void hash(const uint8_t *input, size_t size, uint8_t *output, cryptonight_ctx *ctx);
+    static bool hash(const uint8_t *input, size_t size, uint8_t *output, cryptonight_ctx *ctx, uint8_t version);
 
 private:
     static bool selfTest(int algo);

--- a/src/net/Job.h
+++ b/src/net/Job.h
@@ -57,6 +57,7 @@ public:
     inline uint64_t target() const         { return m_target; }
     inline void setNicehash(bool nicehash) { m_nicehash = nicehash; }
     inline void setThreadId(int threadId)  { m_threadId = threadId; }
+    inline uint8_t version() const         { return blob()[0]; }
 
 #   ifdef XMRIG_PROXY_PROJECT
     inline char *rawBlob()                 { return m_rawBlob; }


### PR DESCRIPTION
Implementation notes:

- The c++ version uses a bool template argument to remove branches from aeon hashing.
- The OpenCL version uses a macro define to remove branches from aeon hashing.
- Once again, the first tweak might be suboptimal since it manipulates the scratchpad directly, and doesn't try to manipulate the simd variable.