### PR TITLE
Add GPU Compute Error tracking to API

### DIFF
--- a/src/api/ApiRouter.cpp
+++ b/src/api/ApiRouter.cpp
@@ -23,6 +23,7 @@
 
 #include <math.h>
 #include <string.h>
+#include <string>
 #include <uv.h>
 
 #if _WIN32
@@ -269,6 +270,13 @@ void ApiRouter::getResults(rapidjson::Document &doc) const
     results.AddMember("best",      best, allocator);
     results.AddMember("error_log", rapidjson::Value(rapidjson::kArrayType), allocator);
 
+    rapidjson::Value gpuComputeErrors(rapidjson::kObjectType);
+    for (auto const& gpuError : m_network.gpuComputeErrors){
+        std::string s = std::to_string(gpuError.first);
+        rapidjson::Value index(s.c_str(), s.size(), allocator);
+        gpuComputeErrors.AddMember(index, gpuError.second, allocator);
+    }
+    results.AddMember("gpuComputeErrors", gpuComputeErrors, allocator);
     doc.AddMember("results", results, allocator);
 }
 

--- a/src/api/NetworkState.cpp
+++ b/src/api/NetworkState.cpp
@@ -93,6 +93,10 @@ void NetworkState::add(const SubmitResult &result, const char *error)
     m_latency.push_back(result.elapsed > 0xFFFF ? 0xFFFF : (uint16_t) result.elapsed);
 }
 
+void NetworkState::addGPUComputeError(int threadID){
+    gpuComputeErrors[threadID]++;
+}
+
 
 void NetworkState::setPool(const char *host, int port, const char *ip)
 {

--- a/src/api/NetworkState.h
+++ b/src/api/NetworkState.h
@@ -27,7 +27,7 @@
 
 #include <array>
 #include <vector>
-
+#include <map>
 
 class SubmitResult;
 
@@ -41,11 +41,13 @@ public:
     uint32_t avgTime() const;
     uint32_t latency() const;
     void add(const SubmitResult &result, const char *error);
+    void addGPUComputeError(int threadID);
     void setPool(const char *host, int port, const char *ip);
     void stop();
 
     char pool[256];
     std::array<uint64_t, 10> topDiff { { } };
+    std::map<int, int> gpuComputeErrors;
     uint32_t diff;
     uint64_t accepted;
     uint64_t failures;

--- a/src/interfaces/IJobResultListener.h
+++ b/src/interfaces/IJobResultListener.h
@@ -35,6 +35,7 @@ public:
     virtual ~IJobResultListener() {}
 
     virtual void onJobResult(const JobResult &result) = 0;
+    virtual void onComputeError(int threadID) = 0;
 };
 
 

--- a/src/net/Network.cpp
+++ b/src/net/Network.cpp
@@ -125,6 +125,11 @@ void Network::onJobResult(const JobResult &result)
     m_strategy->submit(result);
 }
 
+void Network::onComputeError(int threadID)
+{
+    m_state.addGPUComputeError(threadID);
+}
+
 
 void Network::onPause(IStrategy *strategy)
 {

--- a/src/net/Network.h
+++ b/src/net/Network.h
@@ -56,6 +56,7 @@ protected:
   void onActive(IStrategy *strategy, Client *client) override;
   void onJob(IStrategy *strategy, Client *client, const Job &job) override;
   void onJobResult(const JobResult &result) override;
+  void onComputeError(int gpuID) override;
   void onPause(IStrategy *strategy) override;
   void onResultAccepted(IStrategy *strategy, Client *client, const SubmitResult &result, const char *error) override;
 

--- a/src/workers/Workers.cpp
+++ b/src/workers/Workers.cpp
@@ -317,6 +317,7 @@ void Workers::onResult(uv_async_t *handle)
             }
 
             if (baton->errors > 0 && !baton->jobs.empty()) {
+                m_listener->onComputeError(baton->jobs[0].threadId());
                 LOG_ERR("THREAD #%d COMPUTE ERROR", baton->jobs[0].threadId());
             }
 


### PR DESCRIPTION
This commit will add a tracking mechanism to log GPU Compute Errors by thread. This could be useful for automated scripts/monitoring setups where keeping track and alerting on GPU Compute Errors is an early indicator of impending failure. API output will include a new "results" member as shown below where the object name is equal to the thread with the failure, and the object value represents the number of failures.

"gpuComputeErrors": {
  "1": 1,
  "2": 2,
  "3": 1,
  "4": 2,
  "5": 1,
  "6": 4,
  "7": 4
}