### PR TITLE
Algo balancing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ set(HEADERS
     src/net/strategies/DonateStrategy.h
     src/Summary.h
     src/version.h
+    src/workers/Benchmark.h
     src/workers/Handle.h
     src/workers/Hashrate.h
     src/workers/OclThread.h
@@ -120,6 +121,7 @@ set(SOURCES
     src/net/Network.cpp
     src/net/strategies/DonateStrategy.cpp
     src/Summary.cpp
+    src/workers/Benchmark.cpp
     src/workers/Handle.cpp
     src/workers/Hashrate.cpp
     src/workers/OclThread.cpp

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,18 @@
+@echo off
+call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+rmdir /S /Q build
+del %~dp0\xmrig-amd-%1-win64.zip
+mkdir build &&^
+cd build &&^
+git clone https://github.com/MoneroOcean/xmrig-amd.git &&^
+git clone https://github.com/xmrig/xmrig-deps.git &&^
+mkdir xmrig-amd\build &&^
+cd xmrig-amd\build &&^
+git checkout %1 &&^
+cmake .. -G "Visual Studio 15 2017 Win64" -DXMRIG_DEPS=%~dp0\build\xmrig-deps\msvc2017\x64 &&^
+msbuild /p:Configuration=Release xmrig-amd.sln &&^
+cd Release &&^
+copy ..\..\src\config.json . &&^
+7za a -tzip -mx %~dp0\xmrig-amd-%1-win64.zip xmrig-amd.exe config.json &&^
+cd %~dp0 &&^
+rmdir /S /Q build

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -132,6 +132,9 @@ int App::exec()
         return 1;
     }
 
+    // save config here to have option to store automatically generated "threads"
+    if (m_controller->config()->isShouldSave()) m_controller->config()->save();
+
     // run benchmark before pool mining or not?
     if (m_controller->config()->get_algo_perf(xmrig::PA_CN) == 0.0f || m_controller->config()->isCalibrateAlgo()) {
         benchmark.set_controller(m_controller); // we need controller there to access config and network objects
@@ -142,10 +145,10 @@ int App::exec()
             : " >>>>> STARTING ALGO PERFORMANCE CALIBRATION (with %i seconds round)",
             m_controller->config()->calibrateAlgoTime()
         );
-        benchmark.start_perf_bench(xmrig::PerfAlgo::PA_CN); // start benchmarking from first PerfAlgo in the list
+        // start benchmarking from first PerfAlgo in the list
+        if (m_controller->config()->get_algo_perf(xmrig::PA_CN) == 0.0f) benchmark.should_save_config();
+        benchmark.start_perf_bench(xmrig::PerfAlgo::PA_CN);
     } else {
-        // save config here to have option to store automatically generated "threads"
-        if (m_controller->config()->isShouldSave()) m_controller->config()->save();
         m_controller->network()->connect();
     }
 

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -6,6 +6,7 @@
  * Copyright 2016      Jay D Dee   <jayddee246@gmail.com>
  * Copyright 2017-2018 XMR-Stak    <https://github.com/fireice-uk>, <https://github.com/psychocrypt>
  * Copyright 2016-2018 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright 2018 MoneroOcean      <https://github.com/MoneroOcean>, <support@moneroocean.stream>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -39,6 +40,7 @@
 #include "Summary.h"
 #include "version.h"
 #include "workers/Workers.h"
+#include "workers/Benchmark.h"
 
 
 #ifndef XMRIG_NO_HTTPD
@@ -83,6 +85,8 @@ App::~App()
 #   endif
 }
 
+// this should be global since we register onJobResult using this object method
+static Benchmark benchmark;
 
 int App::exec()
 {
@@ -128,7 +132,21 @@ int App::exec()
         return 1;
     }
 
-    m_controller->network()->connect();
+    // run benchmark before pool mining or not?
+    if (m_controller->config()->isCalibrateAlgo()) {
+        benchmark.set_controller(m_controller); // we need controller there to access config and network objects
+        Workers::setListener(&benchmark); // register benchmark as job reault listener to compute hashrates there
+        // write text before first benchmark round
+        Log::i()->text(m_controller->config()->isColors()
+            ? GREEN_BOLD(" >>>>> ") WHITE_BOLD("STARTING ALGO PERFORMANCE CALIBRATION")
+            : " >>>>> STARTING ALGO PERFORMANCE CALIBRATION"
+        );
+        benchmark.start_perf_bench(xmrig::PerfAlgo::PA_CN); // start benchmarking from first PerfAlgo in the list
+    } else {
+        // save config here to have option to store automatically generated "threads"
+        if (m_controller->config()->isShouldSave() || m_controller->config()->isSaveConfig()) m_controller->config()->save();
+        m_controller->network()->connect();
+    }
 
     const int r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
     uv_loop_close(uv_default_loop());

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -133,7 +133,7 @@ int App::exec()
     }
 
     // run benchmark before pool mining or not?
-    if (m_controller->config()->isCalibrateAlgo()) {
+    if (m_controller->config()->get_algo_perf(xmrig::PA_CN) == 0.0f || m_controller->config()->isCalibrateAlgo()) {
         benchmark.set_controller(m_controller); // we need controller there to access config and network objects
         Workers::setListener(&benchmark); // register benchmark as job reault listener to compute hashrates there
         // write text before first benchmark round

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -138,6 +138,7 @@ int App::exec()
     // run benchmark before pool mining or not?
     if (m_controller->config()->get_algo_perf(xmrig::PA_CN) == 0.0f || m_controller->config()->isCalibrateAlgo()) {
         benchmark.set_controller(m_controller); // we need controller there to access config and network objects
+        benchmark.set_original_algorithm(m_controller->config()->algorithm());
         Workers::setListener(&benchmark); // register benchmark as job reault listener to compute hashrates there
         // write text before first benchmark round
         Log::i()->text(m_controller->config()->isColors()

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -138,8 +138,9 @@ int App::exec()
         Workers::setListener(&benchmark); // register benchmark as job reault listener to compute hashrates there
         // write text before first benchmark round
         Log::i()->text(m_controller->config()->isColors()
-            ? GREEN_BOLD(" >>>>> ") WHITE_BOLD("STARTING ALGO PERFORMANCE CALIBRATION")
-            : " >>>>> STARTING ALGO PERFORMANCE CALIBRATION"
+            ? GREEN_BOLD(" >>>>> ") WHITE_BOLD("STARTING ALGO PERFORMANCE CALIBRATION (with %i seconds round)")
+            : " >>>>> STARTING ALGO PERFORMANCE CALIBRATION (with %i seconds round)",
+            m_controller->config()->calibrateAlgoTime()
         );
         benchmark.start_perf_bench(xmrig::PerfAlgo::PA_CN); // start benchmarking from first PerfAlgo in the list
     } else {

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -145,7 +145,7 @@ int App::exec()
         benchmark.start_perf_bench(xmrig::PerfAlgo::PA_CN); // start benchmarking from first PerfAlgo in the list
     } else {
         // save config here to have option to store automatically generated "threads"
-        if (m_controller->config()->isShouldSave() || m_controller->config()->isSaveConfig()) m_controller->config()->save();
+        if (m_controller->config()->isShouldSave()) m_controller->config()->save();
         m_controller->network()->connect();
     }
 

--- a/src/amd/GpuContext.h
+++ b/src/amd/GpuContext.h
@@ -74,7 +74,7 @@ struct GpuContext
         Nonce(0)
     {}
 
-    void release() { // stops all opencl kernels and releases all opencl resources (in destructor and copy constructor)
+    void release() { // stops all opencl kernels and releases all opencl resources
         if (CommandQueues) {
             OclLib::finish(CommandQueues);
             OclLib::releaseCommandQueue(CommandQueues);
@@ -84,34 +84,6 @@ struct GpuContext
         for (int i = 0; i < 6; ++ i)  if (ExtraBuffers[i]) OclLib::releaseMemObject(ExtraBuffers[i]);
         for (int i = 0; i < 11; ++ i) if (Kernels[i]) OclLib::releaseKernel(Kernels[i]);
         if (Program) OclLib::releaseProgram(Program);
-    }
-
-    ~GpuContext() { release(); }
-
-    GpuContext& operator=(const GpuContext& other) { // copy contructor we need to override default one to properly release OpenCL stuff
-        release();
-
-        deviceIdx = other.deviceIdx;
-        rawIntensity = other.rawIntensity;
-        workSize = other.workSize;
-        stridedIndex = other.stridedIndex;
-        memChunk = other.memChunk;
-        compMode = other.compMode;
-
-        DeviceID = other.DeviceID;
-        CommandQueues = other.CommandQueues;
-        InputBuffer = other.InputBuffer;
-        OutputBuffer = other.OutputBuffer;
-        for (int i = 0; i < 6; ++ i) ExtraBuffers[i] = other.ExtraBuffers[i];
-        Program = other.Program;
-        for (int i = 0; i < 11; ++ i) Kernels[i] = other.Kernels[i];
-
-        freeMem = other.freeMem;
-        computeUnits = other.computeUnits;
-        name = other.name;
-
-        Nonce = other.Nonce;
-        return *this;
     }
 
     /*Input vars*/

--- a/src/amd/GpuContext.h
+++ b/src/amd/GpuContext.h
@@ -6,6 +6,7 @@
  * Copyright 2016      Jay D Dee   <jayddee246@gmail.com>
  * Copyright 2017-2018 XMR-Stak    <https://github.com/fireice-uk>, <https://github.com/psychocrypt>
  * Copyright 2016-2018 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright 2018 MoneroOcean      <https://github.com/MoneroOcean>, <support@moneroocean.stream>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -25,7 +26,7 @@
 #define __GPUCONTEXT_H__
 
 
-#include "3rdparty/CL/cl.h"
+#include "amd/OclLib.h"
 
 
 #include <stdint.h>
@@ -72,6 +73,46 @@ struct GpuContext
         computeUnits(0),
         Nonce(0)
     {}
+
+    void release() { // stops all opencl kernels and releases all opencl resources (in destructor and copy constructor)
+        if (CommandQueues) {
+            OclLib::finish(CommandQueues);
+            OclLib::releaseCommandQueue(CommandQueues);
+        }
+        if (InputBuffer) OclLib::releaseMemObject(InputBuffer);
+        if (OutputBuffer) OclLib::releaseMemObject(OutputBuffer);
+        for (int i = 0; i < 6; ++ i)  if (ExtraBuffers[i]) OclLib::releaseMemObject(ExtraBuffers[i]);
+        for (int i = 0; i < 11; ++ i) if (Kernels[i]) OclLib::releaseKernel(Kernels[i]);
+        if (Program) OclLib::releaseProgram(Program);
+    }
+
+    ~GpuContext() { release(); }
+
+    GpuContext& operator=(const GpuContext& other) { // copy contructor we need to override default one to properly release OpenCL stuff
+        release();
+
+        deviceIdx = other.deviceIdx;
+        rawIntensity = other.rawIntensity;
+        workSize = other.workSize;
+        stridedIndex = other.stridedIndex;
+        memChunk = other.memChunk;
+        compMode = other.compMode;
+
+        DeviceID = other.DeviceID;
+        CommandQueues = other.CommandQueues;
+        InputBuffer = other.InputBuffer;
+        OutputBuffer = other.OutputBuffer;
+        for (int i = 0; i < 6; ++ i) ExtraBuffers[i] = other.ExtraBuffers[i];
+        Program = other.Program;
+        for (int i = 0; i < 11; ++ i) Kernels[i] = other.Kernels[i];
+
+        freeMem = other.freeMem;
+        computeUnits = other.computeUnits;
+        name = other.name;
+
+        Nonce = other.Nonce;
+        return *this;
+    }
 
     /*Input vars*/
     size_t deviceIdx;

--- a/src/amd/OclCLI.cpp
+++ b/src/amd/OclCLI.cpp
@@ -6,6 +6,7 @@
  * Copyright 2016      Jay D Dee   <jayddee246@gmail.com>
  * Copyright 2017-2018 XMR-Stak    <https://github.com/fireice-uk>, <https://github.com/psychocrypt>
  * Copyright 2016-2018 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright 2018 MoneroOcean      <https://github.com/MoneroOcean>, <support@moneroocean.stream>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -56,7 +57,7 @@ bool OclCLI::setup(std::vector<xmrig::IThread *> &threads)
 }
 
 
-void OclCLI::autoConf(std::vector<xmrig::IThread *> &threads, int *platformIndex, xmrig::Config *config)
+void OclCLI::autoConf(std::vector<xmrig::IThread *> &threads, int *platformIndex, const xmrig::Algorithm& algorithm, xmrig::Config *config)
 {
     *platformIndex = getAMDPlatformIdx(config);
     if (*platformIndex == -1) {
@@ -71,7 +72,7 @@ void OclCLI::autoConf(std::vector<xmrig::IThread *> &threads, int *platformIndex
     }
 
     constexpr size_t byteToMiB = 1024u * 1024u;
-    const size_t hashMemSize   = xmrig::cn_select_memory(config->algorithm().algo());
+    const size_t hashMemSize   = xmrig::cn_select_memory(algorithm.algo());
 
     for (GpuContext &ctx : devices) {
         // Vega APU slow and can cause BSOD, skip from autoconfig.
@@ -96,7 +97,7 @@ void OclCLI::autoConf(std::vector<xmrig::IThread *> &threads, int *platformIndex
             maxThreads = 2024u;
         }
 
-        if (config->algorithm().algo() == xmrig::CRYPTONIGHT_LITE) {
+        if (algorithm.algo() == xmrig::CRYPTONIGHT_LITE) {
             maxThreads *= 2u;
         }
 

--- a/src/amd/OclCLI.h
+++ b/src/amd/OclCLI.h
@@ -6,6 +6,7 @@
  * Copyright 2016      Jay D Dee   <jayddee246@gmail.com>
  * Copyright 2017-2018 XMR-Stak    <https://github.com/fireice-uk>, <https://github.com/psychocrypt>
  * Copyright 2016-2018 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright 2018 MoneroOcean      <https://github.com/MoneroOcean>, <support@moneroocean.stream>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -29,6 +30,7 @@
 
 
 #include "common/xmrig.h"
+#include "common/crypto/Algorithm.h" // need it for new xmrig::Algorithm autoConf param
 
 
 class OclThread;
@@ -46,7 +48,8 @@ public:
     OclCLI();
 
     bool setup(std::vector<xmrig::IThread *> &threads);
-    void autoConf(std::vector<xmrig::IThread *> &threads, int *platformIndex, xmrig::Config *config);
+    // autoConf now takes Algorithm parameter as input
+    void autoConf(std::vector<xmrig::IThread *> &threads, int *platformIndex, const xmrig::Algorithm&, xmrig::Config *config);
     void parseLaunch(const char *arg);
 
     inline void parseAffinity(const char *arg) { parse(m_affinity, arg); }

--- a/src/amd/OclGPU.cpp
+++ b/src/amd/OclGPU.cpp
@@ -7,6 +7,7 @@
  * Copyright 2017-2018 XMR-Stak    <https://github.com/fireice-uk>, <https://github.com/psychocrypt>
  * Copyright 2018      Lee Clagett <https://github.com/vtnerd>
  * Copyright 2016-2018 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright 2018 MoneroOcean      <https://github.com/MoneroOcean>, <support@moneroocean.stream>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -410,7 +411,10 @@ size_t InitOpenCL(GpuContext* ctx, size_t num_gpus, xmrig::Config *config)
         TempDeviceList[i] = DeviceIDList[ctx[i].deviceIdx];
     }
 
-    cl_context opencl_ctx = OclLib::createContext(nullptr, num_gpus, TempDeviceList, nullptr, nullptr, &ret);
+    // we store previous OpenCL context in static variable to be able to release it next time we do algo switch
+    static cl_context opencl_ctx = nullptr;
+    if (opencl_ctx) OclLib::releaseContext(opencl_ctx);
+    opencl_ctx = OclLib::createContext(nullptr, num_gpus, TempDeviceList, nullptr, nullptr, &ret);
     if(ret != CL_SUCCESS) {
         return OCL_ERR_API;
     }

--- a/src/amd/OclGPU.cpp
+++ b/src/amd/OclGPU.cpp
@@ -403,7 +403,7 @@ size_t InitOpenCL(GpuContext* ctx, size_t num_gpus, xmrig::Config *config)
 #   ifdef __GNUC__
     cl_device_id TempDeviceList[num_gpus];
 #   else
-    cl_device_id* TempDeviceList = (cl_device_id*)_alloca(entries * sizeof(cl_device_id));
+    cl_device_id* TempDeviceList = (cl_device_id*)_alloca(num_gpus * sizeof(cl_device_id));
 #   endif
 
     for (size_t i = 0; i < num_gpus; ++i) {

--- a/src/amd/OclLib.cpp
+++ b/src/amd/OclLib.cpp
@@ -6,6 +6,7 @@
  * Copyright 2016      Jay D Dee   <jayddee246@gmail.com>
  * Copyright 2017-2018 XMR-Stak    <https://github.com/fireice-uk>, <https://github.com/psychocrypt>
  * Copyright 2016-2018 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright 2018 MoneroOcean      <https://github.com/MoneroOcean>, <support@moneroocean.stream>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -53,6 +54,11 @@ static const char *kGetPlatformInfo                  = "clGetPlatformInfo";
 static const char *kGetProgramBuildInfo              = "clGetProgramBuildInfo";
 static const char *kGetProgramInfo                   = "clGetProgramInfo";
 static const char *kSetKernelArg                     = "clSetKernelArg";
+static const char *kReleaseContext                   = "clReleaseContext";
+static const char *kReleaseProgram                   = "clReleaseProgram";
+static const char *kReleaseCommandQueue              = "clReleaseCommandQueue";
+static const char *kReleaseMemObject                 = "clReleaseMemObject";
+static const char *kReleaseKernel                    = "clReleaseKernel";
 
 typedef cl_command_queue (CL_API_CALL *createCommandQueueWithProperties_t)(cl_context, cl_device_id, const cl_queue_properties *, cl_int *);
 typedef cl_command_queue (CL_API_CALL *createCommandQueue_t)(cl_context, cl_device_id, cl_command_queue_properties, cl_int *);
@@ -73,6 +79,11 @@ typedef cl_kernel (CL_API_CALL *createKernel_t)(cl_program, const char *, cl_int
 typedef cl_mem (CL_API_CALL *createBuffer_t)(cl_context, cl_mem_flags, size_t, void *, cl_int *);
 typedef cl_program (CL_API_CALL *createProgramWithBinary_t)(cl_context, cl_uint, const cl_device_id *, const size_t *, const unsigned char **, cl_int *, cl_int *);
 typedef cl_program (CL_API_CALL *createProgramWithSource_t)(cl_context, cl_uint, const char **, const size_t *, cl_int *);
+typedef cl_int (CL_API_CALL *releaseContext_t)(cl_context);
+typedef cl_int (CL_API_CALL *releaseProgram_t)(cl_program);
+typedef cl_int (CL_API_CALL *releaseCommandQueue_t)(cl_command_queue);
+typedef cl_int (CL_API_CALL *releaseMemObject_t)(cl_mem);
+typedef cl_int (CL_API_CALL *releaseKernel_t)(cl_kernel);
 
 static createCommandQueueWithProperties_t pCreateCommandQueueWithProperties = nullptr;
 static createCommandQueue_t pCreateCommandQueue                             = nullptr;
@@ -93,6 +104,11 @@ static createKernel_t pCreateKernel                                         = nu
 static createBuffer_t pCreateBuffer                                         = nullptr;
 static createProgramWithBinary_t pCreateProgramWithBinary                   = nullptr;
 static createProgramWithSource_t pCreateProgramWithSource                   = nullptr;
+static releaseContext_t pReleaseContext                                     = nullptr;
+static releaseProgram_t pReleaseProgram                                     = nullptr;
+static releaseCommandQueue_t pReleaseCommandQueue                           = nullptr;
+static releaseMemObject_t pReleaseMemObject                                 = nullptr;
+static releaseKernel_t pReleaseKernel                                       = nullptr;
 
 #define DLSYM(x) if (uv_dlsym(&oclLib, k##x, reinterpret_cast<void**>(&p##x)) == -1) { return false; }
 
@@ -128,6 +144,11 @@ bool OclLib::load()
     DLSYM(CreateBuffer);
     DLSYM(CreateProgramWithBinary);
     DLSYM(CreateProgramWithSource);
+    DLSYM(ReleaseContext);
+    DLSYM(ReleaseProgram);
+    DLSYM(ReleaseCommandQueue);
+    DLSYM(ReleaseMemObject);
+    DLSYM(ReleaseKernel);
 
     uv_dlsym(&oclLib, kCreateCommandQueueWithProperties, reinterpret_cast<void**>(&pCreateCommandQueueWithProperties));
 
@@ -334,4 +355,43 @@ cl_program OclLib::createProgramWithSource(cl_context context, cl_uint count, co
     }
 
     return result;
+}
+
+cl_int OclLib::releaseContext(cl_context context)
+{
+    assert(pReleaseContext != nullptr);
+
+    return pReleaseContext(context);
+}
+
+
+cl_int OclLib::releaseProgram(cl_program program)
+{
+    assert(pReleaseProgram != nullptr);
+
+    return pReleaseProgram(program);
+}
+
+
+cl_int OclLib::releaseCommandQueue(cl_command_queue command_queue)
+{
+    assert(pReleaseCommandQueue != nullptr);
+
+    return pReleaseCommandQueue(command_queue);
+}
+
+
+cl_int OclLib::releaseMemObject(cl_mem memobj)
+{
+    assert(pReleaseMemObject != nullptr);
+
+    return pReleaseMemObject(memobj);
+}
+
+
+cl_int OclLib::releaseKernel(cl_kernel kernel)
+{
+    assert(pReleaseKernel != nullptr);
+
+    return pReleaseKernel(kernel);
 }

--- a/src/amd/OclLib.h
+++ b/src/amd/OclLib.h
@@ -6,6 +6,7 @@
  * Copyright 2016      Jay D Dee   <jayddee246@gmail.com>
  * Copyright 2017-2018 XMR-Stak    <https://github.com/fireice-uk>, <https://github.com/psychocrypt>
  * Copyright 2016-2018 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright 2018 MoneroOcean      <https://github.com/MoneroOcean>, <support@moneroocean.stream>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -51,6 +52,12 @@ public:
     static cl_mem createBuffer(cl_context context, cl_mem_flags flags, size_t size, void *host_ptr, cl_int *errcode_ret);
     static cl_program createProgramWithBinary(cl_context context, cl_uint num_devices, const cl_device_id *device_list, const size_t *lengths, const unsigned char **binaries, cl_int *binary_status, cl_int *errcode_ret);
     static cl_program createProgramWithSource(cl_context context, cl_uint count, const char **strings, const size_t *lengths, cl_int *errcode_ret);
+    // we need to properly release OpenCL we created to be able to do algo switching
+    static cl_int releaseContext(cl_context context);
+    static cl_int releaseProgram(cl_program program);
+    static cl_int releaseCommandQueue(cl_command_queue command_queue);
+    static cl_int releaseMemObject(cl_mem memobj);
+    static cl_int releaseKernel(cl_kernel kernel);
 
 private:
     static bool load();

--- a/src/amd/opencl/cryptonight.cl
+++ b/src/amd/opencl/cryptonight.cl
@@ -468,9 +468,11 @@ __kernel void cn0(__global ulong *input, __global uint4 *Scratchpad, __global ul
     mem_fence(CLK_LOCAL_MEM_FENCE);
 
 #   if (ALGO == CRYPTONIGHT_HEAVY)
-    {
-        __local uint4 xin[8][WORKSIZE];
+    __local uint4 xin[8][WORKSIZE];
+#   endif
 
+#   if (ALGO == CRYPTONIGHT_HEAVY)
+    {
         /* Also left over threads perform this loop.
          * The left over thread results will be ignored
          */

--- a/src/common/config/CommonConfig.cpp
+++ b/src/common/config/CommonConfig.cpp
@@ -47,6 +47,7 @@ xmrig::CommonConfig::CommonConfig() :
     m_colors(true),
     m_dryRun(false),
     m_calibrateAlgo(false),
+    m_calibrateAlgoTime(60),
     m_saveConfig(false),
     m_syslog(false),
 
@@ -354,6 +355,12 @@ bool xmrig::CommonConfig::parseInt(int key, int arg)
     case PrintTimeKey: /* --print-time */
         if (arg >= 0 && arg <= 3600) {
             m_printTime = arg;
+        }
+        break;
+
+    case CalibrateAlgoTimeKey: /* --calibrate-algo-time */
+        if (arg >= 5 && arg <= 3600) {
+            m_calibrateAlgoTime = arg;
         }
         break;
 

--- a/src/common/config/CommonConfig.cpp
+++ b/src/common/config/CommonConfig.cpp
@@ -6,6 +6,7 @@
  * Copyright 2016      Jay D Dee   <jayddee246@gmail.com>
  * Copyright 2017-2018 XMR-Stak    <https://github.com/fireice-uk>, <https://github.com/psychocrypt>
  * Copyright 2016-2018 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright 2018 MoneroOcean      <https://github.com/MoneroOcean>, <support@moneroocean.stream>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -183,6 +184,14 @@ bool xmrig::CommonConfig::parseBoolean(int key, bool enable)
         m_dryRun = enable;
         break;
 
+    case IConfig::CalibrateAlgoKey: /* --calibrate-algo */
+        m_calibrateAlgo = enable;
+        break;
+
+    case IConfig::SaveConfigKey: /* --save-config */
+        m_saveConfig = enable;
+        break;
+
     default:
         break;
     }
@@ -267,6 +276,8 @@ bool xmrig::CommonConfig::parseString(int key, const char *arg)
     case NicehashKey:   /* --nicehash */
     case ApiIPv6Key:    /* --api-ipv6 */
     case DryRunKey:     /* --dry-run */
+    case CalibrateAlgoKey: /* --calibrate-algo */
+    case SaveConfigKey: /* --save-config */
         return parseBoolean(key, true);
 
     case ColorKey:         /* --no-color */

--- a/src/common/config/CommonConfig.cpp
+++ b/src/common/config/CommonConfig.cpp
@@ -46,6 +46,7 @@ xmrig::CommonConfig::CommonConfig() :
     m_background(false),
     m_colors(true),
     m_dryRun(false),
+    m_calibrateAlgo(false),
     m_syslog(false),
 
 #   ifdef XMRIG_PROXY_PROJECT

--- a/src/common/config/CommonConfig.cpp
+++ b/src/common/config/CommonConfig.cpp
@@ -47,6 +47,7 @@ xmrig::CommonConfig::CommonConfig() :
     m_colors(true),
     m_dryRun(false),
     m_calibrateAlgo(false),
+    m_saveConfig(false),
     m_syslog(false),
 
 #   ifdef XMRIG_PROXY_PROJECT

--- a/src/common/config/CommonConfig.cpp
+++ b/src/common/config/CommonConfig.cpp
@@ -48,7 +48,6 @@ xmrig::CommonConfig::CommonConfig() :
     m_dryRun(false),
     m_calibrateAlgo(false),
     m_calibrateAlgoTime(60),
-    m_saveConfig(false),
     m_syslog(false),
 
 #   ifdef XMRIG_PROXY_PROJECT
@@ -191,10 +190,6 @@ bool xmrig::CommonConfig::parseBoolean(int key, bool enable)
         m_calibrateAlgo = enable;
         break;
 
-    case IConfig::SaveConfigKey: /* --save-config */
-        m_saveConfig = enable;
-        break;
-
     default:
         break;
     }
@@ -280,7 +275,6 @@ bool xmrig::CommonConfig::parseString(int key, const char *arg)
     case ApiIPv6Key:    /* --api-ipv6 */
     case DryRunKey:     /* --dry-run */
     case CalibrateAlgoKey: /* --calibrate-algo */
-    case SaveConfigKey: /* --save-config */
         return parseBoolean(key, true);
 
     case ColorKey:         /* --no-color */
@@ -295,6 +289,9 @@ bool xmrig::CommonConfig::parseString(int key, const char *arg)
             return true;
         }
 #       endif
+        return parseUint64(key, strtol(arg, nullptr, 10));
+
+    case CalibrateAlgoTimeKey: /* --calibrate-algo-time */
         return parseUint64(key, strtol(arg, nullptr, 10));
 
     default:

--- a/src/common/config/CommonConfig.h
+++ b/src/common/config/CommonConfig.h
@@ -6,6 +6,7 @@
  * Copyright 2016      Jay D Dee   <jayddee246@gmail.com>
  * Copyright 2017-2018 XMR-Stak    <https://github.com/fireice-uk>, <https://github.com/psychocrypt>
  * Copyright 2016-2018 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright 2018 MoneroOcean      <https://github.com/MoneroOcean>, <support@moneroocean.stream>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -48,6 +49,8 @@ public:
     inline bool isBackground() const               { return m_background; }
     inline bool isColors() const                   { return m_colors; }
     inline bool isDryRun() const                   { return m_dryRun; }
+    inline bool isCalibrateAlgo() const            { return m_calibrateAlgo; }
+    inline bool isSaveConfig() const               { return m_saveConfig; }
     inline bool isSyslog() const                   { return m_syslog; }
     inline const char *apiToken() const            { return m_apiToken.data(); }
     inline const char *apiWorkerId() const         { return m_apiWorkerId.data(); }
@@ -87,6 +90,8 @@ protected:
     bool m_background;
     bool m_colors;
     bool m_dryRun;
+    bool m_calibrateAlgo;
+    bool m_saveConfig;
     bool m_syslog;
     bool m_watch;
     int m_apiPort;

--- a/src/common/config/CommonConfig.h
+++ b/src/common/config/CommonConfig.h
@@ -50,6 +50,7 @@ public:
     inline bool isColors() const                   { return m_colors; }
     inline bool isDryRun() const                   { return m_dryRun; }
     inline bool isCalibrateAlgo() const            { return m_calibrateAlgo; }
+    inline int  calibrateAlgoTime() const          { return m_calibrateAlgoTime; }
     inline bool isSaveConfig() const               { return m_saveConfig; }
     inline bool isSyslog() const                   { return m_syslog; }
     inline const char *apiToken() const            { return m_apiToken.data(); }
@@ -92,6 +93,7 @@ protected:
     bool m_colors;
     bool m_dryRun;
     bool m_calibrateAlgo;
+    int  m_calibrateAlgoTime;
     bool m_saveConfig;
     bool m_syslog;
     bool m_watch;

--- a/src/common/config/CommonConfig.h
+++ b/src/common/config/CommonConfig.h
@@ -66,6 +66,7 @@ public:
 
     inline bool isWatch() const override               { return m_watch && !m_fileName.isNull(); }
     inline const Algorithm &algorithm() const override { return m_algorithm; }
+    inline void set_algorithm(const Algorithm& algorithm) { m_algorithm = algorithm; }
     inline const char *fileName() const override       { return m_fileName.data(); }
 
     bool save() override;

--- a/src/common/config/CommonConfig.h
+++ b/src/common/config/CommonConfig.h
@@ -51,7 +51,6 @@ public:
     inline bool isDryRun() const                   { return m_dryRun; }
     inline bool isCalibrateAlgo() const            { return m_calibrateAlgo; }
     inline int  calibrateAlgoTime() const          { return m_calibrateAlgoTime; }
-    inline bool isSaveConfig() const               { return m_saveConfig; }
     inline bool isSyslog() const                   { return m_syslog; }
     inline const char *apiToken() const            { return m_apiToken.data(); }
     inline const char *apiWorkerId() const         { return m_apiWorkerId.data(); }
@@ -94,7 +93,6 @@ protected:
     bool m_dryRun;
     bool m_calibrateAlgo;
     int  m_calibrateAlgoTime;
-    bool m_saveConfig;
     bool m_syslog;
     bool m_watch;
     int m_apiPort;

--- a/src/common/crypto/Algorithm.cpp
+++ b/src/common/crypto/Algorithm.cpp
@@ -7,6 +7,7 @@
  * Copyright 2017-2018 XMR-Stak    <https://github.com/fireice-uk>, <https://github.com/psychocrypt>
  * Copyright 2018      Lee Clagett <https://github.com/vtnerd>
  * Copyright 2016-2018 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright 2018 MoneroOcean      <https://github.com/MoneroOcean>, <support@moneroocean.stream>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -222,4 +223,52 @@ const char *xmrig::Algorithm::name(bool shortName) const
     }
 
     return "invalid";
+}
+
+
+// returns string name of the PerfAlgo
+const char *xmrig::Algorithm::perfAlgoName(const xmrig::PerfAlgo pa) {
+    static const char* perf_algo_names[xmrig::PerfAlgo::PA_MAX] = {
+        "cn",
+        "cn-fast",
+        "cn-lite",
+        "cn-heavy",
+    };
+    return perf_algo_names[pa];
+}
+
+// constructs Algorithm from PerfAlgo
+xmrig::Algorithm::Algorithm(const xmrig::PerfAlgo pa) {
+    switch (pa) {
+       case PA_CN:
+           m_algo    = xmrig::CRYPTONIGHT;
+           m_variant = xmrig::VARIANT_1;
+           break;
+       case PA_CN_FAST:
+           m_algo    = xmrig::CRYPTONIGHT;
+           m_variant = xmrig::VARIANT_MSR;
+           break;
+       case PA_CN_LITE:
+           m_algo    = xmrig::CRYPTONIGHT_LITE;
+           m_variant = xmrig::VARIANT_1;
+           break;
+       case PA_CN_HEAVY:
+           m_algo    = xmrig::CRYPTONIGHT_HEAVY;
+           m_variant = xmrig::VARIANT_0;
+           break;
+       default:
+           m_algo    = xmrig::INVALID_ALGO;
+           m_variant = xmrig::VARIANT_AUTO;
+    }
+}
+
+// returns PerfAlgo that corresponds to current Algorithm
+xmrig::PerfAlgo xmrig::Algorithm::perf_algo() const {
+    if (m_variant == VARIANT_MSR) return PA_CN_FAST;
+    switch (m_algo) {
+       case CRYPTONIGHT:       return PA_CN;
+       case CRYPTONIGHT_LITE:  return PA_CN_LITE;
+       case CRYPTONIGHT_HEAVY: return PA_CN_HEAVY;
+       default: return PA_INVALID;
+    }
 }

--- a/src/common/crypto/Algorithm.h
+++ b/src/common/crypto/Algorithm.h
@@ -7,6 +7,7 @@
  * Copyright 2017-2018 XMR-Stak    <https://github.com/fireice-uk>, <https://github.com/psychocrypt>
  * Copyright 2018      Lee Clagett <https://github.com/vtnerd>
  * Copyright 2016-2018 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright 2018 MoneroOcean      <https://github.com/MoneroOcean>, <support@moneroocean.stream>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -49,6 +50,9 @@ public:
         setAlgo(algo);
     }
 
+    // constructs Algorithm from PerfAlgo
+    Algorithm(const xmrig::PerfAlgo);
+
     inline Algorithm(const char *algo)
     {
         parseAlgorithm(algo);
@@ -56,8 +60,10 @@ public:
 
     bool isEqual(const Algorithm &other) const { return m_algo == other.m_algo && m_variant == other.m_variant; }
     inline Algo algo() const                   { return m_algo; }
+    xmrig::PerfAlgo perf_algo() const; // returns PerfAlgo that corresponds to current Algorithm
     inline const char *name() const            { return name(false); }
     inline const char *shortName() const       { return name(true); }
+    static const char *perfAlgoName(xmrig::PerfAlgo); // returns string name of the PerfAlgo
     inline Variant variant() const             { return m_variant; }
     inline void setVariant(Variant variant)    { m_variant = variant; }
 

--- a/src/common/crypto/Algorithm.h
+++ b/src/common/crypto/Algorithm.h
@@ -44,7 +44,7 @@ public:
         m_variant(VARIANT_AUTO)
     {}
 
-    inline Algorithm(Algo algo, Variant variant) :
+    inline Algorithm(Algo algo, Variant variant = VARIANT_AUTO) :
         m_variant(variant)
     {
         setAlgo(algo);

--- a/src/common/interfaces/IConfig.h
+++ b/src/common/interfaces/IConfig.h
@@ -69,7 +69,8 @@ public:
         NicehashKey       = 1006,
         PrintTimeKey      = 1007,
         CalibrateAlgoKey  = 10001,
-        SaveConfigKey     = 10002,
+        CalibrateAlgoTimeKey = 10002,
+        SaveConfigKey     = 10003,
 
         // xmrig cpu
         AVKey             = 'v',

--- a/src/common/interfaces/IConfig.h
+++ b/src/common/interfaces/IConfig.h
@@ -5,6 +5,7 @@
  * Copyright 2014-2016 Wolf9466    <https://github.com/OhGodAPet>
  * Copyright 2016      Jay D Dee   <jayddee246@gmail.com>
  * Copyright 2016-2018 XMRig       <support@xmrig.com>
+ * Copyright 2018 MoneroOcean      <https://github.com/MoneroOcean>, <support@moneroocean.stream>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -67,6 +68,8 @@ public:
         CPUPriorityKey    = 1021,
         NicehashKey       = 1006,
         PrintTimeKey      = 1007,
+        CalibrateAlgoKey  = 10001,
+        SaveConfigKey     = 10002,
 
         // xmrig cpu
         AVKey             = 'v',

--- a/src/common/interfaces/IConfig.h
+++ b/src/common/interfaces/IConfig.h
@@ -68,9 +68,8 @@ public:
         CPUPriorityKey    = 1021,
         NicehashKey       = 1006,
         PrintTimeKey      = 1007,
-        CalibrateAlgoKey  = 10001,
+        CalibrateAlgoKey     = 10001,
         CalibrateAlgoTimeKey = 10002,
-        SaveConfigKey     = 10003,
 
         // xmrig cpu
         AVKey             = 'v',

--- a/src/common/net/Client.h
+++ b/src/common/net/Client.h
@@ -6,6 +6,7 @@
  * Copyright 2016      Jay D Dee   <jayddee246@gmail.com>
  * Copyright 2017-2018 XMR-Stak    <https://github.com/fireice-uk>, <https://github.com/psychocrypt>
  * Copyright 2016-2018 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright 2018 MoneroOcean      <https://github.com/MoneroOcean>, <support@moneroocean.stream>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -74,7 +75,6 @@ public:
     inline int id() const                             { return m_id; }
     inline SocketState state() const                  { return m_state; }
     inline uint16_t port() const                      { return m_pool.port(); }
-    inline void setAlgo(const xmrig::Algorithm &algo) { m_pool.setAlgo(algo); }
     inline void setQuiet(bool quiet)                  { m_quiet = quiet; }
     inline void setRetries(int retries)               { m_retries = retries; }
     inline void setRetryPause(int ms)                 { m_retryPause = ms; }

--- a/src/common/net/Job.cpp
+++ b/src/common/net/Job.cpp
@@ -7,6 +7,7 @@
  * Copyright 2017-2018 XMR-Stak    <https://github.com/fireice-uk>, <https://github.com/psychocrypt>
  * Copyright 2018      Lee Clagett <https://github.com/vtnerd>
  * Copyright 2016-2018 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright 2018 MoneroOcean      <https://github.com/MoneroOcean>, <support@moneroocean.stream>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -118,6 +119,12 @@ bool Job::setBlob(const char *blob)
 #   endif
 
     return true;
+}
+
+// for algo benchmarking
+void Job::setRawBlob(const uint8_t *blob, const size_t size)
+{
+    memcpy(m_blob, blob, m_size = size);
 }
 
 

--- a/src/common/net/Job.h
+++ b/src/common/net/Job.h
@@ -7,6 +7,7 @@
  * Copyright 2017-2018 XMR-Stak    <https://github.com/fireice-uk>, <https://github.com/psychocrypt>
  * Copyright 2018      Lee Clagett <https://github.com/vtnerd>
  * Copyright 2016-2018 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright 2018 MoneroOcean      <https://github.com/MoneroOcean>, <support@moneroocean.stream>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -42,7 +43,10 @@ public:
     ~Job();
 
     bool setBlob(const char *blob);
+    void setRawBlob(const uint8_t *blob, const size_t size); // for algo benchmarking
     bool setTarget(const char *target);
+    // for algo benchmarking to set PoW variant
+    void setAlgorithm(const xmrig::Algorithm& algorithm) { m_algorithm = algorithm; }
     xmrig::Variant variant() const;
 
     inline bool isNicehash() const                    { return m_nicehash; }

--- a/src/common/net/Pool.cpp
+++ b/src/common/net/Pool.cpp
@@ -6,6 +6,7 @@
  * Copyright 2016      Jay D Dee   <jayddee246@gmail.com>
  * Copyright 2017-2018 XMR-Stak    <https://github.com/fireice-uk>, <https://github.com/psychocrypt>
  * Copyright 2016-2018 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright 2018 MoneroOcean      <https://github.com/MoneroOcean>, <support@moneroocean.stream>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -48,6 +49,20 @@ Pool::Pool() :
     m_keepAlive(0),
     m_port(kDefaultPort)
 {
+    // here xmrig now resuts all possible supported algorithms
+    m_algorithms.push_back(xmrig::Algorithm(xmrig::CRYPTONIGHT, xmrig::VARIANT_1));
+    m_algorithms.push_back(xmrig::Algorithm(xmrig::CRYPTONIGHT, xmrig::VARIANT_0));
+    m_algorithms.push_back(xmrig::Algorithm(xmrig::CRYPTONIGHT, xmrig::VARIANT_XTL));
+    m_algorithms.push_back(xmrig::Algorithm(xmrig::CRYPTONIGHT, xmrig::VARIANT_MSR));
+    m_algorithms.push_back(xmrig::Algorithm(xmrig::CRYPTONIGHT, xmrig::VARIANT_XAO));
+    m_algorithms.push_back(xmrig::Algorithm(xmrig::CRYPTONIGHT, xmrig::VARIANT_RTO));
+
+    m_algorithms.push_back(xmrig::Algorithm(xmrig::CRYPTONIGHT_LITE, xmrig::VARIANT_1));
+    m_algorithms.push_back(xmrig::Algorithm(xmrig::CRYPTONIGHT_LITE, xmrig::VARIANT_0));
+
+    m_algorithms.push_back(xmrig::Algorithm(xmrig::CRYPTONIGHT_HEAVY, xmrig::VARIANT_0));
+    m_algorithms.push_back(xmrig::Algorithm(xmrig::CRYPTONIGHT_HEAVY, xmrig::VARIANT_XHV));
+    m_algorithms.push_back(xmrig::Algorithm(xmrig::CRYPTONIGHT_HEAVY, xmrig::VARIANT_TUBE));
 }
 
 
@@ -233,16 +248,6 @@ void Pool::adjust(const xmrig::Algorithm &algorithm)
         m_algorithm.setAlgo(algorithm.algo());
         adjustVariant(algorithm.variant());
     }
-
-    rebuild();
-}
-
-
-void Pool::setAlgo(const xmrig::Algorithm &algorithm)
-{
-    m_algorithm = algorithm;
-
-    rebuild();
 }
 
 
@@ -282,17 +287,6 @@ bool Pool::parseIPv6(const char *addr)
     m_port = static_cast<uint16_t>(strtol(port + 1, nullptr, 10));
 
     return true;
-}
-
-
-void Pool::addVariant(xmrig::Variant variant)
-{
-    const xmrig::Algorithm algorithm(m_algorithm.algo(), variant);
-    if (!algorithm.isValid() || m_algorithm == algorithm) {
-        return;
-    }
-
-    m_algorithms.push_back(algorithm);
 }
 
 
@@ -362,29 +356,5 @@ void Pool::adjustVariant(const xmrig::Variant variantHint)
     else {
         m_algorithm.setVariant(VARIANT_1);
     }
-#   endif
-}
-
-
-void Pool::rebuild()
-{
-    m_algorithms.clear();
-
-    if (!m_algorithm.isValid()) {
-        return;
-    }
-
-    m_algorithms.push_back(m_algorithm);
-
-#   ifndef XMRIG_PROXY_PROJECT
-    addVariant(xmrig::VARIANT_1);
-    addVariant(xmrig::VARIANT_0);
-    addVariant(xmrig::VARIANT_XTL);
-    addVariant(xmrig::VARIANT_TUBE);
-    addVariant(xmrig::VARIANT_MSR);
-    addVariant(xmrig::VARIANT_XHV);
-    addVariant(xmrig::VARIANT_XAO);
-    addVariant(xmrig::VARIANT_RTO);
-    addVariant(xmrig::VARIANT_AUTO);
 #   endif
 }

--- a/src/common/net/Pool.h
+++ b/src/common/net/Pool.h
@@ -6,6 +6,7 @@
  * Copyright 2016      Jay D Dee   <jayddee246@gmail.com>
  * Copyright 2017-2018 XMR-Stak    <https://github.com/fireice-uk>, <https://github.com/psychocrypt>
  * Copyright 2016-2018 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright 2018 MoneroOcean      <https://github.com/MoneroOcean>, <support@moneroocean.stream>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -78,7 +79,6 @@ public:
     bool setUserpass(const char *userpass);
     rapidjson::Value toJSON(rapidjson::Document &doc) const;
     void adjust(const xmrig::Algorithm &algorithm);
-    void setAlgo(const xmrig::Algorithm &algorithm);
 
 #   ifdef APP_DEBUG
     void print() const;
@@ -86,9 +86,7 @@ public:
 
 private:
     bool parseIPv6(const char *addr);
-    void addVariant(xmrig::Variant variant);
     void adjustVariant(const xmrig::Variant variantHint);
-    void rebuild();
 
     bool m_nicehash;
     int m_keepAlive;

--- a/src/common/xmrig.h
+++ b/src/common/xmrig.h
@@ -34,7 +34,8 @@ enum Algo {
     INVALID_ALGO = -1,
     CRYPTONIGHT,       /* CryptoNight (Monero) */
     CRYPTONIGHT_LITE,  /* CryptoNight-Lite (AEON) */
-    CRYPTONIGHT_HEAVY  /* CryptoNight-Heavy (RYO) */
+    CRYPTONIGHT_HEAVY, /* CryptoNight-Heavy (RYO) */
+    ALGO_MAX
 };
 
 // algorithms that can has different performance

--- a/src/common/xmrig.h
+++ b/src/common/xmrig.h
@@ -6,6 +6,7 @@
  * Copyright 2016      Jay D Dee   <jayddee246@gmail.com>
  * Copyright 2017-2018 XMR-Stak    <https://github.com/fireice-uk>, <https://github.com/psychocrypt>
  * Copyright 2016-2018 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright 2018 MoneroOcean      <https://github.com/MoneroOcean>, <support@moneroocean.stream>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -36,6 +37,15 @@ enum Algo {
     CRYPTONIGHT_HEAVY  /* CryptoNight-Heavy (RYO) */
 };
 
+// algorithms that can has different performance
+enum PerfAlgo {
+    PA_INVALID = -1,
+    PA_CN,       /* CryptoNight (Monero) */
+    PA_CN_FAST,  /* CryptoNight-Fast (Masari) */
+    PA_CN_LITE,  /* CryptoNight-Lite (AEON) */
+    PA_CN_HEAVY, /* CryptoNight-Heavy (RYO) */
+    PA_MAX
+};
 
 //--av=1 For CPUs with hardware AES.
 //--av=2 Lower power mode (double hash) of 1.

--- a/src/config.json
+++ b/src/config.json
@@ -27,6 +27,12 @@
     "retries": 5,
     "retry-pause": 5,
     "threads": null,
+    "algo-perf": {
+        "cn":      1000.0,
+        "cn-fast": 2000.0,
+        "cn-lite": 2000.0,
+        "cn-heavy": 700.0
+    },
     "user-agent": null,
     "syslog": false,
     "watch": false

--- a/src/config.json
+++ b/src/config.json
@@ -28,6 +28,8 @@
     "retry-pause": 5,
     "threads": null,
     "algo-perf": null,
+    "calibrate-algo": false,
+    "calibrate-algo-time": 60,
     "user-agent": null,
     "syslog": false,
     "watch": false

--- a/src/config.json
+++ b/src/config.json
@@ -27,12 +27,7 @@
     "retries": 5,
     "retry-pause": 5,
     "threads": null,
-    "algo-perf": {
-        "cn":      1000.0,
-        "cn-fast": 2000.0,
-        "cn-lite": 2000.0,
-        "cn-heavy": 700.0
-    },
+    "algo-perf": null,
     "user-agent": null,
     "syslog": false,
     "watch": false

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -153,6 +153,9 @@ void xmrig::Config::getJSON(rapidjson::Document &doc) const
     }
     doc.AddMember("algo-perf", algo_perf, allocator);
 
+    doc.AddMember("calibrate-algo", isCalibrateAlgo(), allocator);
+    doc.AddMember("calibrate-algo-time", calibrateAlgoTime(), allocator);
+
     doc.AddMember("user-agent", userAgent() ? Value(StringRef(userAgent())).Move() : Value(kNullType).Move(), allocator);
     doc.AddMember("syslog",     isSyslog(), allocator);
     doc.AddMember("watch",      m_watch, allocator);

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -61,7 +61,7 @@ xmrig::Config::Config() : xmrig::CommonConfig(),
     // not defined algo performance is considered to be 0
     for (int a = 0; a != xmrig::PerfAlgo::PA_MAX; ++ a) {
         const xmrig::PerfAlgo pa = static_cast<xmrig::PerfAlgo>(a);
-        m_algo_perf[pa] = 0;
+        m_algo_perf[pa] = 0.0f;
     }
 }
 
@@ -301,6 +301,8 @@ void xmrig::Config::parseJSON(const rapidjson::Document &doc)
             }
         }
     }
+
+    if (m_algo_perf[xmrig::PA_CN] == 0.0f) m_shouldSave = true;
 }
 
 

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -300,7 +300,9 @@ void xmrig::Config::parseJSON(const rapidjson::Document &doc)
             const xmrig::PerfAlgo pa = static_cast<xmrig::PerfAlgo>(a);
             const rapidjson::Value &key = algo_perf[xmrig::Algorithm::perfAlgoName(pa)];
             if (key.IsDouble()) {
-                m_algo_perf[pa] = key.GetDouble();
+                m_algo_perf[pa] = static_cast<float>(key.GetDouble());
+            } else if (key.IsInt()) {
+                m_algo_perf[pa] = static_cast<float>(key.GetInt());
             }
         }
     }

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -59,8 +59,8 @@ public:
     inline bool isShouldSave() const                     { return m_shouldSave; }
     inline const char *loader() const                    { return m_loader.data(); }
     // access to m_threads taking into accoun that it is now separated for each perf algo
-    inline const std::vector<IThread *> &threads(const xmrig::PerfAlgo pa = PA_INVALID) const {
-        return m_threads[pa == PA_INVALID ? m_algorithm.perf_algo() : pa];
+    inline const std::vector<IThread *> &threads(const xmrig::Algo algo = ALGO_INVALID) const {
+        return m_threads[algo == ALGO_INVALID ? m_algorithm.algo() : algo];
     }
     inline int platformIndex() const                     { return m_platformIndex; }
 
@@ -77,10 +77,10 @@ protected:
     bool parseUint64(int key, uint64_t arg) override;
     void parseJSON(const rapidjson::Document &doc) override;
     // parse specific perf algo (or generic) threads config
-    void parseThreadsJSON(const rapidjson::Value &threads, xmrig::PerfAlgo);
+    void parseThreadsJSON(const rapidjson::Value &threads, xmrig::Algo);
 
 private:
-    void parseThread(const rapidjson::Value &object, const xmrig::PerfAlgo);
+    void parseThread(const rapidjson::Value &object, const xmrig::Algo);
 
     bool m_autoConf;
     bool m_cache;
@@ -88,7 +88,7 @@ private:
     int m_platformIndex;
     OclCLI m_oclCLI;
     // threads config for each perf algo
-    std::vector<IThread *> m_threads[xmrig::PerfAlgo::PA_MAX];
+    std::vector<IThread *> m_threads[xmrig::Algo::ALGO_MAX];
     // perf algo hashrate results
     float m_algo_perf[xmrig::PerfAlgo::PA_MAX];
     xmrig::c_str m_loader;

--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -59,8 +59,8 @@ public:
     inline bool isShouldSave() const                     { return m_shouldSave; }
     inline const char *loader() const                    { return m_loader.data(); }
     // access to m_threads taking into accoun that it is now separated for each perf algo
-    inline const std::vector<IThread *> &threads(const xmrig::Algo algo = ALGO_INVALID) const {
-        return m_threads[algo == ALGO_INVALID ? m_algorithm.algo() : algo];
+    inline const std::vector<IThread *> &threads(const xmrig::Algo algo = INVALID_ALGO) const {
+        return m_threads[algo == INVALID_ALGO ? m_algorithm.algo() : algo];
     }
     inline int platformIndex() const                     { return m_platformIndex; }
 

--- a/src/core/ConfigLoader_platform.h
+++ b/src/core/ConfigLoader_platform.h
@@ -6,6 +6,7 @@
  * Copyright 2016      Jay D Dee   <jayddee246@gmail.com>
  * Copyright 2017-2018 XMR-Stak    <https://github.com/fireice-uk>, <https://github.com/psychocrypt>
  * Copyright 2016-2018 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright 2018 MoneroOcean      <https://github.com/MoneroOcean>, <support@moneroocean.stream>
  *
  *
  *   This program is free software: you can redistribute it and/or modify
@@ -54,6 +55,7 @@ Options:\n\
                              cryptonight-heavy\n"
 #endif
 "\
+  --calibrate-algo         run benchmarks before mining to measure hashrates of all supported algos\n\
   -o, --url=URL            URL of mining server\n\
   -O, --userpass=U:P       username:password pair for mining server\n\
   -u, --user=USERNAME      username for mining server\n\
@@ -87,6 +89,7 @@ Options:\n\
       --api-worker-id=ID   custom worker-id for API\n\
       --api-ipv6           enable IPv6 support for API\n\
       --api-no-restricted  enable full remote access (only if API token set)\n\
+      --save-config        save config file including generated configuration\n\
   -h, --help               display this help and exit\n\
   -V, --version            output version information and exit\n\
 ";
@@ -106,6 +109,8 @@ static struct option const options[] = {
     { "config",            1, nullptr, xmrig::IConfig::ConfigKey         },
     { "donate-level",      1, nullptr, xmrig::IConfig::DonateLevelKey    },
     { "dry-run",           0, nullptr, xmrig::IConfig::DryRunKey         },
+    { "calibrate-algo",    0, nullptr, xmrig::IConfig::CalibrateAlgoKey  },
+    { "save-config",       0, nullptr, xmrig::IConfig::SaveConfigKey     },
     { "help",              0, nullptr, xmrig::IConfig::HelpKey           },
     { "keepalive",         0, nullptr, xmrig::IConfig::KeepAliveKey      },
     { "log-file",          1, nullptr, xmrig::IConfig::LogFileKey        },

--- a/src/core/ConfigLoader_platform.h
+++ b/src/core/ConfigLoader_platform.h
@@ -90,7 +90,6 @@ Options:\n\
       --api-worker-id=ID   custom worker-id for API\n\
       --api-ipv6           enable IPv6 support for API\n\
       --api-no-restricted  enable full remote access (only if API token set)\n\
-      --save-config        save config file including generated configuration\n\
   -h, --help               display this help and exit\n\
   -V, --version            output version information and exit\n\
 ";
@@ -110,9 +109,8 @@ static struct option const options[] = {
     { "config",            1, nullptr, xmrig::IConfig::ConfigKey         },
     { "donate-level",      1, nullptr, xmrig::IConfig::DonateLevelKey    },
     { "dry-run",           0, nullptr, xmrig::IConfig::DryRunKey         },
-    { "calibrate-algo",    0, nullptr, xmrig::IConfig::CalibrateAlgoKey  },
+    { "calibrate-algo",      0, nullptr, xmrig::IConfig::CalibrateAlgoKey      },
     { "calibrate-algo-time", 1, nullptr, xmrig::IConfig::CalibrateAlgoTimeKey  },
-    { "save-config",       0, nullptr, xmrig::IConfig::SaveConfigKey     },
     { "help",              0, nullptr, xmrig::IConfig::HelpKey           },
     { "keepalive",         0, nullptr, xmrig::IConfig::KeepAliveKey      },
     { "log-file",          1, nullptr, xmrig::IConfig::LogFileKey        },
@@ -147,6 +145,8 @@ static struct option const config_options[] = {
     { "colors",            0, nullptr, xmrig::IConfig::ColorKey       },
     { "donate-level",      1, nullptr, xmrig::IConfig::DonateLevelKey },
     { "dry-run",           0, nullptr, xmrig::IConfig::DryRunKey      },
+    { "calibrate-algo",      0, nullptr, xmrig::IConfig::CalibrateAlgoKey      },
+    { "calibrate-algo-time", 1, nullptr, xmrig::IConfig::CalibrateAlgoTimeKey  },
     { "log-file",          1, nullptr, xmrig::IConfig::LogFileKey     },
     { "print-time",        1, nullptr, xmrig::IConfig::PrintTimeKey   },
     { "retries",           1, nullptr, xmrig::IConfig::RetriesKey     },

--- a/src/core/ConfigLoader_platform.h
+++ b/src/core/ConfigLoader_platform.h
@@ -56,6 +56,7 @@ Options:\n\
 #endif
 "\
   --calibrate-algo         run benchmarks before mining to measure hashrates of all supported algos\n\
+  --calibrate-algo-time=N  time in seconds to run each algo benchmark round (default: 60)\n\
   -o, --url=URL            URL of mining server\n\
   -O, --userpass=U:P       username:password pair for mining server\n\
   -u, --user=USERNAME      username for mining server\n\
@@ -110,6 +111,7 @@ static struct option const options[] = {
     { "donate-level",      1, nullptr, xmrig::IConfig::DonateLevelKey    },
     { "dry-run",           0, nullptr, xmrig::IConfig::DryRunKey         },
     { "calibrate-algo",    0, nullptr, xmrig::IConfig::CalibrateAlgoKey  },
+    { "calibrate-algo-time", 1, nullptr, xmrig::IConfig::CalibrateAlgoTimeKey  },
     { "save-config",       0, nullptr, xmrig::IConfig::SaveConfigKey     },
     { "help",              0, nullptr, xmrig::IConfig::HelpKey           },
     { "keepalive",         0, nullptr, xmrig::IConfig::KeepAliveKey      },

--- a/src/core/Controller.cpp
+++ b/src/core/Controller.cpp
@@ -6,6 +6,7 @@
  * Copyright 2016      Jay D Dee   <jayddee246@gmail.com>
  * Copyright 2017-2018 XMR-Stak    <https://github.com/fireice-uk>, <https://github.com/psychocrypt>
  * Copyright 2016-2018 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright 2018 MoneroOcean      <https://github.com/MoneroOcean>, <support@moneroocean.stream>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -103,7 +104,8 @@ int xmrig::Controller::init(int argc, char **argv)
 {
     Cpu::init();
 
-    d_ptr->config = xmrig::Config::load(argc, argv, this);
+    // init pconfig global pointer to config
+    pconfig = d_ptr->config = xmrig::Config::load(argc, argv, this);
     if (!d_ptr->config) {
         return 1;
     }

--- a/src/crypto/CryptoNight.cpp
+++ b/src/crypto/CryptoNight.cpp
@@ -7,6 +7,7 @@
  * Copyright 2017-2018 XMR-Stak    <https://github.com/fireice-uk>, <https://github.com/psychocrypt>
  * Copyright 2018      Lee Clagett <https://github.com/vtnerd>
  * Copyright 2016-2018 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright 2018 MoneroOcean      <https://github.com/MoneroOcean>, <support@moneroocean.stream>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -152,6 +153,7 @@ CryptoNight::cn_hash_fun CryptoNight::fn(xmrig::Algo algorithm, xmrig::AlgoVerif
 
 cryptonight_ctx *CryptoNight::createCtx(xmrig::Algo algorithm)
 {
+    m_algorithm = algorithm; // register algo switch in m_algorithm after its context creation
     cryptonight_ctx *ctx = static_cast<cryptonight_ctx *>(_mm_malloc(sizeof(cryptonight_ctx), 16));
     ctx->memory          = static_cast<uint8_t *>(_mm_malloc(xmrig::cn_select_memory(algorithm), 16));
 

--- a/src/workers/Benchmark.cpp
+++ b/src/workers/Benchmark.cpp
@@ -79,7 +79,7 @@ void Benchmark::onJobResult(const JobResult& result) {
             start_perf_bench(next_pa);
         } else { // end of benchmarks and switching to jobs from the pool (network)
             m_pa = xmrig::PA_INVALID;
-            m_controller->config()->save(); // save config with measured algo-perf
+            if (m_controller->config()->isShouldSave() || m_controller->config()->isSaveConfig()) m_controller->config()->save(); // save config with measured algo-perf
             Workers::pause(); // do not compute anything before job from the pool
             m_controller->network()->connect();
         }

--- a/src/workers/Benchmark.cpp
+++ b/src/workers/Benchmark.cpp
@@ -81,6 +81,7 @@ void Benchmark::onJobResult(const JobResult& result) {
             m_pa = xmrig::PA_INVALID;
             if (m_shouldSaveConfig) m_controller->config()->save(); // save config with measured algo-perf
             Workers::pause(); // do not compute anything before job from the pool
+            Workers::switch_algo(m_algorithm_orig); // switch workers to the original algorithm
             m_controller->network()->connect();
         }
     }

--- a/src/workers/Benchmark.cpp
+++ b/src/workers/Benchmark.cpp
@@ -79,7 +79,7 @@ void Benchmark::onJobResult(const JobResult& result) {
             start_perf_bench(next_pa);
         } else { // end of benchmarks and switching to jobs from the pool (network)
             m_pa = xmrig::PA_INVALID;
-            if (m_controller->config()->isShouldSave()) m_controller->config()->save(); // save config with measured algo-perf
+            if (m_shouldSaveConfig) m_controller->config()->save(); // save config with measured algo-perf
             Workers::pause(); // do not compute anything before job from the pool
             m_controller->network()->connect();
         }

--- a/src/workers/Benchmark.cpp
+++ b/src/workers/Benchmark.cpp
@@ -65,7 +65,7 @@ void Benchmark::onJobResult(const JobResult& result) {
     ++ m_hash_count;
     const uint64_t now = get_now();
     if (!m_time_start) m_time_start = now; // time of measurements start (in ms)
-    else if (now - m_time_start > m_controller->config()->calibrateAlgoTime()*1000) { // end of benchmark round for m_pa
+    else if (now - m_time_start > static_cast<unsigned>(m_controller->config()->calibrateAlgoTime())*1000) { // end of benchmark round for m_pa
         const float hashrate = static_cast<float>(m_hash_count) * result.diff / (now - m_time_start) * 1000.0f;
         m_controller->config()->set_algo_perf(m_pa, hashrate); // store hashrate result
         Log::i()->text(m_controller->config()->isColors()

--- a/src/workers/Benchmark.cpp
+++ b/src/workers/Benchmark.cpp
@@ -79,7 +79,7 @@ void Benchmark::onJobResult(const JobResult& result) {
             start_perf_bench(next_pa);
         } else { // end of benchmarks and switching to jobs from the pool (network)
             m_pa = xmrig::PA_INVALID;
-            if (m_controller->config()->isShouldSave() || m_controller->config()->isSaveConfig()) m_controller->config()->save(); // save config with measured algo-perf
+            if (m_controller->config()->isShouldSave()) m_controller->config()->save(); // save config with measured algo-perf
             Workers::pause(); // do not compute anything before job from the pool
             m_controller->network()->connect();
         }

--- a/src/workers/Benchmark.cpp
+++ b/src/workers/Benchmark.cpp
@@ -1,0 +1,92 @@
+/* XMRig
+ * Copyright 2010      Jeff Garzik <jgarzik@pobox.com>
+ * Copyright 2012-2014 pooler      <pooler@litecoinpool.org>
+ * Copyright 2014      Lucas Jones <https://github.com/lucasjones>
+ * Copyright 2014-2016 Wolf9466    <https://github.com/OhGodAPet>
+ * Copyright 2016      Jay D Dee   <jayddee246@gmail.com>
+ * Copyright 2017-2018 XMR-Stak    <https://github.com/fireice-uk>, <https://github.com/psychocrypt>
+ * Copyright 2016-2018 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright 2018 MoneroOcean      <https://github.com/MoneroOcean>, <support@moneroocean.stream>
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "workers/Benchmark.h"
+#include "workers/Workers.h"
+#include "core/Config.h"
+#include "net/Network.h"
+#include "common/log/Log.h"
+#include <chrono>
+
+// start performance measurements for specified perf algo
+void Benchmark::start_perf_bench(const xmrig::PerfAlgo pa) {
+    Workers::switch_algo(xmrig::Algorithm(pa)); // switch workers to new algo (Algo part)
+
+    // prepare test job for benchmark runs
+    Job job;
+    job.setPoolId(-100); // to make sure we can detect benchmark jobs
+    job.setId(xmrig::Algorithm::perfAlgoName(pa)); // need to set different id so that workers will see job change
+    const static uint8_t test_input[76] = {
+        0x99, // 0x99 here to trigger all future algo versions for auto veriant detection based on block version
+        0x05, 0xA0, 0xDB, 0xD6, 0xBF, 0x05, 0xCF, 0x16, 0xE5, 0x03, 0xF3, 0xA6, 0x6F, 0x78, 0x00,
+        0x7C, 0xBF, 0x34, 0x14, 0x43, 0x32, 0xEC, 0xBF, 0xC2, 0x2E, 0xD9, 0x5C, 0x87, 0x00, 0x38, 0x3B,
+        0x30, 0x9A, 0xCE, 0x19, 0x23, 0xA0, 0x96, 0x4B, 0x00, 0x00, 0x00, 0x08, 0xBA, 0x93, 0x9A, 0x62,
+        0x72, 0x4C, 0x0D, 0x75, 0x81, 0xFC, 0xE5, 0x76, 0x1E, 0x9D, 0x8A, 0x0E, 0x6A, 0x1C, 0x3F, 0x92,
+        0x4F, 0xDD, 0x84, 0x93, 0xD1, 0x11, 0x56, 0x49, 0xC0, 0x5E, 0xB6, 0x01,
+    };
+    job.setRawBlob(test_input, 76);
+    job.setTarget("FFFFFFFFFFFFFF00"); // set difficulty to 256 cause onJobResult after every 256-th computed hash
+    job.setAlgorithm(xmrig::Algorithm(pa)); // set job algo (for Variant part)
+    m_pa = pa; // current perf algo
+    m_hash_count = 0; // number of hashes calculated for current perf algo
+    m_time_start = 0; // init time of measurements start (in ms) during the first onJobResult
+    Workers::setJob(job, false); // set job for workers to compute
+}
+
+void Benchmark::onJobResult(const JobResult& result) {
+    if (result.poolId != -100) { // switch to network pool jobs
+        Workers::setListener(m_controller->network());
+        static_cast<IJobResultListener*>(m_controller->network())->onJobResult(result);
+        return;
+    }
+    // ignore benchmark results for other perf algo
+    if (m_pa == xmrig::PA_INVALID || result.jobId != xmrig::Id(xmrig::Algorithm::perfAlgoName(m_pa))) return;
+    ++ m_hash_count;
+    const uint64_t now = get_now();
+    if (!m_time_start) m_time_start = now; // time of measurements start (in ms)
+    else if (now - m_time_start > m_bench_secs*1000) { // end of benchmark round for m_pa
+        const float hashrate = static_cast<float>(m_hash_count) * result.diff / (now - m_time_start) * 1000.0f;
+        m_controller->config()->set_algo_perf(m_pa, hashrate); // store hashrate result
+        Log::i()->text(m_controller->config()->isColors()
+            ? GREEN_BOLD(" ===> ") CYAN_BOLD("%s") WHITE_BOLD(" hashrate: ") CYAN_BOLD("%f")
+            : " ===> %s hasrate: %f",
+            xmrig::Algorithm::perfAlgoName(m_pa),
+            hashrate
+        );
+        const xmrig::PerfAlgo next_pa = static_cast<xmrig::PerfAlgo>(m_pa + 1); // compute next perf algo to benchmark
+        if (next_pa != xmrig::PerfAlgo::PA_MAX) {
+            start_perf_bench(next_pa);
+        } else { // end of benchmarks and switching to jobs from the pool (network)
+            m_pa = xmrig::PA_INVALID;
+            m_controller->config()->save(); // save config with measured algo-perf
+            Workers::pause(); // do not compute anything before job from the pool
+            m_controller->network()->connect();
+        }
+    }
+}
+
+uint64_t Benchmark::get_now() const { // get current time in ms
+    using namespace std::chrono;
+    return time_point_cast<milliseconds>(high_resolution_clock::now()).time_since_epoch().count();
+}

--- a/src/workers/Benchmark.cpp
+++ b/src/workers/Benchmark.cpp
@@ -65,7 +65,7 @@ void Benchmark::onJobResult(const JobResult& result) {
     ++ m_hash_count;
     const uint64_t now = get_now();
     if (!m_time_start) m_time_start = now; // time of measurements start (in ms)
-    else if (now - m_time_start > m_bench_secs*1000) { // end of benchmark round for m_pa
+    else if (now - m_time_start > m_controller->config()->calibrateAlgoTime()*1000) { // end of benchmark round for m_pa
         const float hashrate = static_cast<float>(m_hash_count) * result.diff / (now - m_time_start) * 1000.0f;
         m_controller->config()->set_algo_perf(m_pa, hashrate); // store hashrate result
         Log::i()->text(m_controller->config()->isColors()

--- a/src/workers/Benchmark.h
+++ b/src/workers/Benchmark.h
@@ -31,6 +31,7 @@
 #include "core/Controller.h"
 
 class Benchmark : public IJobResultListener {
+    bool m_shouldSaveConfig; // should save config after all benchmark rounds
     xmrig::PerfAlgo m_pa;  // current perf algo we benchmark
     uint64_t m_hash_count; // number of hashes calculated for current perf algo
     uint64_t m_time_start; // time of measurements start for current perf algo (in ms)
@@ -41,9 +42,10 @@ class Benchmark : public IJobResultListener {
     void onJobResult(const JobResult&) override; // onJobResult is called after each computed benchmark hash
 
     public:
-        Benchmark() {}
+        Benchmark() : m_shouldSaveConfig(false) {}
         virtual ~Benchmark() {}
 
         void set_controller(xmrig::Controller* controller) { m_controller = controller; }
+        void should_save_config() { m_shouldSaveConfig = true; }
         void start_perf_bench(const xmrig::PerfAlgo); // start benchmark for specified perf algo
 };

--- a/src/workers/Benchmark.h
+++ b/src/workers/Benchmark.h
@@ -1,0 +1,50 @@
+/* XMRig
+ * Copyright 2010      Jeff Garzik <jgarzik@pobox.com>
+ * Copyright 2012-2014 pooler      <pooler@litecoinpool.org>
+ * Copyright 2014      Lucas Jones <https://github.com/lucasjones>
+ * Copyright 2014-2016 Wolf9466    <https://github.com/OhGodAPet>
+ * Copyright 2016      Jay D Dee   <jayddee246@gmail.com>
+ * Copyright 2017-2018 XMR-Stak    <https://github.com/fireice-uk>, <https://github.com/psychocrypt>
+ * Copyright 2016-2018 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright 2018 MoneroOcean      <https://github.com/MoneroOcean>, <support@moneroocean.stream>
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#include "common/xmrig.h"
+#include "interfaces/IJobResultListener.h"
+#include "core/Controller.h"
+
+class Benchmark : public IJobResultListener {
+    const uint64_t m_bench_secs = 30; // time in seconds to benchmark each perf algo
+    xmrig::PerfAlgo m_pa;  // current perf algo we benchmark
+    uint64_t m_hash_count; // number of hashes calculated for current perf algo
+    uint64_t m_time_start; // time of measurements start for current perf algo (in ms)
+    xmrig::Controller* m_controller; // to get access to config and network
+
+    uint64_t get_now() const; // get current time in ms
+
+    void onJobResult(const JobResult&) override; // onJobResult is called after each computed benchmark hash
+
+    public:
+        Benchmark() {}
+        virtual ~Benchmark() {}
+
+        void set_controller(xmrig::Controller* controller) { m_controller = controller; }
+        void start_perf_bench(const xmrig::PerfAlgo); // start benchmark for specified perf algo
+};

--- a/src/workers/Benchmark.h
+++ b/src/workers/Benchmark.h
@@ -36,6 +36,7 @@ class Benchmark : public IJobResultListener {
     uint64_t m_hash_count; // number of hashes calculated for current perf algo
     uint64_t m_time_start; // time of measurements start for current perf algo (in ms)
     xmrig::Controller* m_controller; // to get access to config and network
+    const xmrig::Algorithm m_algorithm_orig; // previous algorithm to restore after benchmarking
 
     uint64_t get_now() const; // get current time in ms
 
@@ -46,6 +47,7 @@ class Benchmark : public IJobResultListener {
         virtual ~Benchmark() {}
 
         void set_controller(xmrig::Controller* controller) { m_controller = controller; }
+        void set_original_algorithm(const xmrig::Algorithm& algorithm) { m_algorithm_orig = algorithm; }
         void should_save_config() { m_shouldSaveConfig = true; }
         void start_perf_bench(const xmrig::PerfAlgo); // start benchmark for specified perf algo
 };

--- a/src/workers/Benchmark.h
+++ b/src/workers/Benchmark.h
@@ -29,6 +29,7 @@
 #include "common/xmrig.h"
 #include "interfaces/IJobResultListener.h"
 #include "core/Controller.h"
+#include "common/crypto/Algorithm.h"
 
 class Benchmark : public IJobResultListener {
     bool m_shouldSaveConfig; // should save config after all benchmark rounds

--- a/src/workers/Benchmark.h
+++ b/src/workers/Benchmark.h
@@ -31,7 +31,6 @@
 #include "core/Controller.h"
 
 class Benchmark : public IJobResultListener {
-    const uint64_t m_bench_secs = 30; // time in seconds to benchmark each perf algo
     xmrig::PerfAlgo m_pa;  // current perf algo we benchmark
     uint64_t m_hash_count; // number of hashes calculated for current perf algo
     uint64_t m_time_start; // time of measurements start for current perf algo (in ms)

--- a/src/workers/Benchmark.h
+++ b/src/workers/Benchmark.h
@@ -36,7 +36,7 @@ class Benchmark : public IJobResultListener {
     uint64_t m_hash_count; // number of hashes calculated for current perf algo
     uint64_t m_time_start; // time of measurements start for current perf algo (in ms)
     xmrig::Controller* m_controller; // to get access to config and network
-    const xmrig::Algorithm m_algorithm_orig; // previous algorithm to restore after benchmarking
+    xmrig::Algorithm m_algorithm_orig; // previous algorithm to restore after benchmarking
 
     uint64_t get_now() const; // get current time in ms
 

--- a/src/workers/Workers.cpp
+++ b/src/workers/Workers.cpp
@@ -243,7 +243,7 @@ bool Workers::switch_algo(const xmrig::Algorithm& algorithm)
     m_sequence = 1;
     m_paused   = 1;
 
-    const std::vector<xmrig::IThread *> &threads = m_controller->config()->threads(algorithm.perf_algo());
+    const std::vector<xmrig::IThread *> &threads = m_controller->config()->threads(algorithm.algo());
     m_controller->config()->set_algorithm(algorithm);
 
     Log::i()->text(m_controller->config()->isColors()

--- a/src/workers/Workers.cpp
+++ b/src/workers/Workers.cpp
@@ -6,6 +6,7 @@
  * Copyright 2016      Jay D Dee   <jayddee246@gmail.com>
  * Copyright 2017-2018 XMR-Stak    <https://github.com/fireice-uk>, <https://github.com/psychocrypt>
  * Copyright 2016-2018 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright 2018 MoneroOcean      <https://github.com/MoneroOcean>, <support@moneroocean.stream>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -212,13 +213,78 @@ bool Workers::start(xmrig::Controller *controller)
         handle->start(Workers::onReady);
     }
 
-    if (controller->config()->isShouldSave()) {
-        controller->config()->save();
+    return true;
+}
+
+void Workers::soft_stop() // stop current workers leaving uv stuff intact (used in switch_algo)
+{
+    if (m_hashrate) {
+        m_hashrate->stop();
+        delete m_hashrate;
+    }
+
+    m_sequence = 0;
+    m_paused   = 0;
+
+    for (size_t i = 0; i < m_workers.size(); ++i) {
+        m_workers[i]->join();
+        delete m_workers[i];
+    }
+    m_workers.clear();
+}
+
+// setups workers based on specified algorithm (or its basic perf algo more specifically)
+bool Workers::switch_algo(const xmrig::Algorithm& algorithm)
+{
+    if (m_controller->config()->algorithm().algo() == algorithm.algo()) return true;
+
+    soft_stop();
+
+    m_sequence = 1;
+    m_paused   = 1;
+
+    const std::vector<xmrig::IThread *> &threads = m_controller->config()->threads(algorithm.perf_algo());
+    m_controller->config()->set_algorithm(algorithm);
+
+    Log::i()->text(m_controller->config()->isColors()
+        ? GREEN_BOLD(" >>> ") WHITE_BOLD("ALGO CHANGE: ") CYAN_BOLD("%s")
+        : " >>> ALGO CHANGE: %s",
+        algorithm.name()
+    );
+
+    size_t ways = 0;
+    for (const xmrig::IThread *thread : threads) {
+       ways += thread->multiway();
+    }
+
+    m_threadsCount = threads.size();
+    m_hashrate = new Hashrate(m_threadsCount, m_controller);
+
+    contexts.resize(m_threadsCount);
+
+    for (size_t i = 0; i < m_threadsCount; ++i) {
+        const OclThread *thread = static_cast<OclThread *>(threads[i]);
+        contexts[i] = GpuContext(thread->index(), thread->intensity(), thread->worksize(), thread->stridedIndex(), thread->memChunk(), thread->isCompMode());
+    }
+
+    if (InitOpenCL(contexts.data(), m_threadsCount, m_controller->config()) != 0) {
+        return false;
+    }
+
+    uint32_t offset = 0;
+
+    size_t i = 0;
+    for (xmrig::IThread *thread : threads) {
+        Handle *handle = new Handle(i, thread, &contexts[i], offset, ways);
+        offset += thread->multiway();
+        i++;
+
+        m_workers.push_back(handle);
+        handle->start(Workers::onReady);
     }
 
     return true;
 }
-
 
 void Workers::stop()
 {
@@ -294,12 +360,18 @@ void Workers::onResult(uv_async_t *handle)
                 return;
             }
 
-            cryptonight_ctx *ctx = CryptoNight::createCtx(baton->jobs[0].algorithm().algo());
+            xmrig::Algo algo = baton->jobs[0].algorithm().algo();
+            cryptonight_ctx *ctx = CryptoNight::createCtx(algo);
 
             for (const Job &job : baton->jobs) {
                 JobResult result(job);
 
-                if (CryptoNight::hash(job, result, ctx)) {
+                if (job.algorithm().algo() != algo) {
+                    CryptoNight::freeCtx(ctx);
+                    ctx = CryptoNight::createCtx(algo = job.algorithm().algo());
+                }
+
+                if (job.poolId() == -100 || CryptoNight::hash(job, result, ctx)) {
                     baton->results.push_back(result);
                 }
                 else {
@@ -317,7 +389,7 @@ void Workers::onResult(uv_async_t *handle)
             }
 
             if (baton->errors > 0 && !baton->jobs.empty()) {
-                LOG_ERR("THREAD #%d COMPUTE ERROR", baton->jobs[0].threadId());
+                LOG_ERR("THREAD #%d COMPUTE ERROR(s): %i", baton->jobs[0].threadId(), baton->errors);
             }
 
             delete baton;

--- a/src/workers/Workers.cpp
+++ b/src/workers/Workers.cpp
@@ -231,6 +231,8 @@ void Workers::soft_stop() // stop current workers leaving uv stuff intact (used 
         delete m_workers[i];
     }
     m_workers.clear();
+
+    for (size_t i = 0; i < contexts.size(); ++i) contexts[i].release();
 }
 
 // setups workers based on specified algorithm (or its basic perf algo more specifically)

--- a/src/workers/Workers.h
+++ b/src/workers/Workers.h
@@ -6,6 +6,7 @@
  * Copyright 2016      Jay D Dee   <jayddee246@gmail.com>
  * Copyright 2017-2018 XMR-Stak    <https://github.com/fireice-uk>, <https://github.com/psychocrypt>
  * Copyright 2016-2018 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright 2018 MoneroOcean      <https://github.com/MoneroOcean>, <support@moneroocean.stream>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -56,6 +57,8 @@ public:
     static void setEnabled(bool enabled);
     static void setJob(const Job &job, bool donate);
     static bool start(xmrig::Controller *controller);
+    // setups workers based on specified algorithm (or its basic perf algo more specifically)
+    static bool switch_algo(const xmrig::Algorithm&);
     static void stop();
     static void submit(const Job &result);
 
@@ -76,6 +79,7 @@ private:
     static void onResult(uv_async_t *handle);
     static void onTick(uv_timer_t *handle);
     static void start(IWorker *worker);
+    static void soft_stop(); // stop current workers leaving uv stuff intact (used in switch_algo)
 
     static bool m_active;
     static bool m_enabled;


### PR DESCRIPTION
This is suggested implementation of #618 for xmrig-amd (not in xmrig-proxy):

In short it do the following:

1) Adds --calibrate-algo (functionality that measured relevant algo hashrates) and --save-config (that can save algo hashrates into algo-perf section of config.json file) switches.
2) Adds extended "threads" option that allows to specify separate thread profiles for different algorithms.
3) All possible algorithms are now reported by miner to the pool (not only variants of the the same base Algo).
4) Allows miner to change algorithm to any supported one specified by "algo" pool job switch.

P.S. The most serious workaround was done to pass config object (with algo hashrates) to Client object via global config object pointer (pconfig).