### PR TITLE
APPLE FIX --- test needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 find_package(UV REQUIRED)
 
 include(cmake/flags.cmake)
+include(cmake/OpenCL.cmake)
 
 add_definitions(/DCL_TARGET_OPENCL_VERSION=200)
 add_definitions(/DCL_USE_DEPRECATED_OPENCL_1_2_APIS)
@@ -253,4 +254,4 @@ if (BUILD_STATIC)
 endif()
 
 add_executable(${PROJECT_NAME} ${HEADERS} ${SOURCES} ${SOURCES_OS} ${SOURCES_CPUID} ${HEADERS_CRYPTO} ${SOURCES_CRYPTO} ${SOURCES_SYSLOG} ${HTTPD_SOURCES})
-target_link_libraries(${PROJECT_NAME} ${UV_LIBRARIES} ${MHD_LIBRARY} ${EXTRA_LIBS} ${LIBS})
+target_link_libraries(${PROJECT_NAME} ${UV_LIBRARIES} ${MHD_LIBRARY} ${EXTRA_LIBS} ${LIBS} ${OpenCL_LIBRARY})

--- a/cmake/OpenCL.cmake
+++ b/cmake/OpenCL.cmake
@@ -1,0 +1,58 @@
+# try to find AMD OpenCL before NVIDIA OpenCL
+find_path(OpenCL_INCLUDE_DIR
+    NAMES
+        CL/cl.h
+        OpenCL/cl.h
+    NO_DEFAULT_PATH
+    PATHS
+        ENV "OpenCL_ROOT"
+        ENV AMDAPPSDKROOT
+        ENV ATISTREAMSDKROOT
+        ENV "PROGRAMFILES(X86)"
+    PATH_SUFFIXES
+        include
+        OpenCL/common/inc
+        "AMD APP/include")
+
+if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+    find_library(OpenCL_LIBRARY
+    NAMES 
+        OpenCL
+        OpenCL.lib
+    NO_DEFAULT_PATH
+    PATHS
+        ENV "OpenCL_ROOT"
+        ENV AMDAPPSDKROOT
+        ENV ATISTREAMSDKROOT
+        ENV "PROGRAMFILES(X86)"
+    PATH_SUFFIXES
+        "AMD APP/lib/x86_64"
+        "AMD APP SDK/lib/x86_64"
+        lib/x86_64
+        lib/x64
+        OpenCL/common/lib/x64)
+else()
+    find_library(OpenCL_LIBRARY
+    NAMES 
+        OpenCL
+        OpenCL.lib
+    NO_DEFAULT_PATH
+    PATHS
+        ENV "OpenCL_ROOT"
+        ENV AMDAPPSDKROOT
+        ENV ATISTREAMSDKROOT
+        ENV "PROGRAMFILES(X86)"
+    PATH_SUFFIXES
+        "AMD APP/lib/x86"
+        "AMD APP SDK/lib/x86"
+        lib/x86
+        OpenCL/common/lib/x86)
+endif()
+
+# find package will use the previews searched path variables
+find_package(OpenCL)
+if (OpenCL_FOUND)
+    include_directories(SYSTEM ${OpenCL_INCLUDE_DIRS})
+    #set(LIBS ${LIBS} ${OpenCL_LIBRARY})
+    link_directories(${OpenCL_LIBRARY})
+endif()

--- a/src/Summary.cpp
+++ b/src/Summary.cpp
@@ -26,8 +26,11 @@
 #include <stdio.h>
 #include <uv.h>
 
-
-#include "3rdparty/CL/cl.h"
+#if defined(__APPLE__)
+#   include <OpenCL/cl.h>
+#else
+#   include "3rdparty/CL/cl.h"
+#endif
 #include "common/log/Log.h"
 #include "common/net/Pool.h"
 #include "core/Config.h"

--- a/src/amd/GpuContext.h
+++ b/src/amd/GpuContext.h
@@ -25,9 +25,11 @@
 #define __GPUCONTEXT_H__
 
 
-#include "3rdparty/CL/cl.h"
-
-
+#if defined(__APPLE__)
+#   include <OpenCL/cl.h>
+#else
+#   include "3rdparty/CL/cl.h"
+#endif
 #include <stdint.h>
 #include <string>
 

--- a/src/amd/OclLib.cpp
+++ b/src/amd/OclLib.cpp
@@ -54,7 +54,7 @@ static const char *kGetProgramBuildInfo              = "clGetProgramBuildInfo";
 static const char *kGetProgramInfo                   = "clGetProgramInfo";
 static const char *kSetKernelArg                     = "clSetKernelArg";
 
-typedef cl_command_queue (CL_API_CALL *createCommandQueueWithProperties_t)(cl_context, cl_device_id, const cl_queue_properties *, cl_int *);
+typedef cl_command_queue (CL_API_CALL *createCommandQueueWithProperties_t)(cl_context, cl_device_id, const cl_context_properties *, cl_int *);
 typedef cl_command_queue (CL_API_CALL *createCommandQueue_t)(cl_context, cl_device_id, cl_command_queue_properties, cl_int *);
 typedef cl_context (CL_API_CALL *createContext_t)(const cl_context_properties *, cl_uint, const cl_device_id *, void (CL_CALLBACK *pfn_notify)(const char *, const void *, size_t, void *), void *, cl_int *);
 typedef cl_int (CL_API_CALL *buildProgram_t)(cl_program, cl_uint, const cl_device_id *, const char *, void (CL_CALLBACK *pfn_notify)(cl_program, void *), void *);
@@ -140,7 +140,7 @@ cl_command_queue OclLib::createCommandQueue(cl_context context, cl_device_id dev
     cl_command_queue result;
 
     if (pCreateCommandQueueWithProperties) {
-        const cl_queue_properties commandQueueProperties[] = { 0, 0, 0 };
+        const cl_context_properties commandQueueProperties[] = { 0, 0, 0 };
         result = pCreateCommandQueueWithProperties(context, device, commandQueueProperties, errcode_ret);
     }
     else {

--- a/src/amd/OclLib.h
+++ b/src/amd/OclLib.h
@@ -25,7 +25,11 @@
 #define __OCLLIB_H__
 
 
-#include "3rdparty/CL/cl.h"
+#if defined(__APPLE__)
+#   include <OpenCL/cl.h>
+#else
+#   include <CL/cl.h>
+#endif
 
 
 class OclLib

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -44,15 +44,16 @@ xmrig::Config::Config() : xmrig::CommonConfig(),
     m_autoConf(false),
     m_cache(true),
     m_shouldSave(false),
-    m_platformIndex(0),
-#   ifdef _WIN32
-    m_loader("OpenCL.dll")
-#   else
-    m_loader("libOpenCL.so")
+#   ifndef __APPLE__
+#    ifdef _WIN32
+     m_loader("OpenCL.dll"),
+#    else
+     m_loader("libOpenCL.so"),
+#    endif
 #   endif
+    m_platformIndex(0)
 {
 }
-
 
 xmrig::Config::~Config()
 {


### PR DESCRIPTION
Please review this.
Just force to use Apple's OpenCL Framework instead of embedded one (if __APPLE__ detected).
I have to re-include OpenCL.cmake (not working without, error below) and change two vars in OclLib.cpp.
`cl_queue_properties --> cl_context_properties` Apple's OCL Frameworkork refering to them (compiler error below).

I don't know if this break something else (I have just Apple miner to test it).

OpenCL.cmake not included error:
```
 * VERSIONS     XMRig/2.7.3-beta libuv/1.18.0 OpenCL/1.2 clang/8.0.0
 * CPU          Intel(R) Xeon(R) CPU           X5550  @ 2.67GHz x64 -AES
 * ALGO         cryptonight, donate=5%
 * POOL #1      127.0.0.1:7777 variant 1
 * COMMANDS     hashrate, pause, resume
[2018-08-20 16:58:44] Failed to load OpenCL runtime: dlsym(RTLD_DEFAULT, clCreateCommandQueue): symbol not found
[2018-08-20 16:58:44] Failed to start threads
```

OclLib.cpp's const name compile error:
```
/Users/user/xmrig-amd/src/amd/OclLib.cpp:57:108: error: unknown type name 'cl_queue_properties'; did you mean 'cl_context_properties'?
typedef cl_command_queue (CL_API_CALL *createCommandQueueWithProperties_t)(cl_context, cl_device_id, const cl_queue_properties *, cl_int *);
                                                                                                           ^~~~~~~~~~~~~~~~~~~
                                                                                                           cl_context_properties
/System/Library/Frameworks/OpenCL.framework/Headers/cl.h:62:29: note: 'cl_context_properties' declared here
typedef intptr_t            cl_context_properties;
                            ^
/Users/user/xmrig-amd/src/amd/OclLib.cpp:143:15: error: unknown type name 'cl_queue_properties'; did you mean 'cl_context_properties'?
        const cl_queue_properties commandQueueProperties[] = { 0, 0, 0 };
              ^~~~~~~~~~~~~~~~~~~
              cl_context_properties
/System/Library/Frameworks/OpenCL.framework/Headers/cl.h:62:29: note: 'cl_context_properties' declared here
typedef intptr_t            cl_context_properties;
                            ^
2 errors generated.
```