### PR TITLE
Cryptonight variant 2 support

### DIFF
--- a/src/amd/GpuContext.h
+++ b/src/amd/GpuContext.h
@@ -45,6 +45,7 @@ struct GpuContext
         stridedIndex(1),
         memChunk(2),
         compMode(1),
+        unrollFactor(8),
         DeviceID(nullptr),
         CommandQueues(nullptr),
         InputBuffer(nullptr),
@@ -58,13 +59,14 @@ struct GpuContext
     {}
 
 
-    inline GpuContext(size_t index, size_t intensity, size_t worksize, int stridedIndex, int memChunk, bool compMode) :
+    inline GpuContext(size_t index, size_t intensity, size_t worksize, int stridedIndex, int memChunk, bool compMode, int unrollFactor) :
         deviceIdx(index),
         rawIntensity(intensity),
         workSize(worksize),
         stridedIndex(stridedIndex),
         memChunk(memChunk),
         compMode(compMode ? 1 : 0),
+        unrollFactor(unrollFactor),
         DeviceID(nullptr),
         CommandQueues(nullptr),
         InputBuffer(nullptr),
@@ -84,6 +86,7 @@ struct GpuContext
     int stridedIndex;
     int memChunk;
     int compMode;
+    int unrollFactor;
 
     /*Output vars*/
     cl_device_id DeviceID;
@@ -92,7 +95,7 @@ struct GpuContext
     cl_mem OutputBuffer;
     cl_mem ExtraBuffers[6];
     cl_program Program;
-    cl_kernel Kernels[11];
+    cl_kernel Kernels[12];
     size_t freeMem;
     int computeUnits;
     std::string name;

--- a/src/amd/OclCLI.cpp
+++ b/src/amd/OclCLI.cpp
@@ -49,7 +49,7 @@ bool OclCLI::setup(std::vector<xmrig::IThread *> &threads)
     }
 
     for (size_t i = 0; i < m_devices.size(); i++) {
-        threads.push_back(new OclThread(m_devices[i], intensity(i), worksize(i), affinity(i)));
+        threads.push_back(new OclThread(m_devices[i], intensity(i), worksize(i), affinity(i), unrollFactor(i)));
     }
 
     return true;
@@ -136,12 +136,18 @@ void OclCLI::parseLaunch(const char *arg)
             else if (count == 2) {
                 m_worksize.push_back(v > 0 ? v : 8);
             }
+            else if (count == 3) {
+                m_unrollFactor.push_back(v > 0 ? v : 8);
+            }
 
             pch = strtok(nullptr, "x");
         }
 
-        if (count == 1) {
+        if (count < 2) {
             m_worksize.push_back(8);
+        }
+        if (count < 3) {
+            m_unrollFactor.push_back(8);
         }
     }
 

--- a/src/amd/OclCLI.h
+++ b/src/amd/OclCLI.h
@@ -57,6 +57,7 @@ private:
     inline int affinity(int index) const  { return get(m_affinity, index, -1); }
     inline int intensity(int index) const { return get(m_intensity, index, 0); }
     inline int worksize(int index) const  { return get(m_worksize, index, 8); }
+    inline int unrollFactor(int index) const { return get(m_unrollFactor, index, 8); }
 
     int get(const std::vector<int> &vector, int index, int defaultValue) const;
     void parse(std::vector<int> &vector, const char *arg) const;
@@ -65,6 +66,7 @@ private:
     std::vector<int> m_devices;
     std::vector<int> m_intensity;
     std::vector<int> m_worksize;
+    std::vector<int> m_unrollFactor;
 };
 
 

--- a/src/amd/OclGPU.cpp
+++ b/src/amd/OclGPU.cpp
@@ -105,6 +105,9 @@ inline static int cnKernelOffset(uint32_t variant)
     case xmrig::VARIANT_TUBE:
         return 10;
 
+    case xmrig::VARIANT_2:
+        return 11;
+
     default:
         break;
     }
@@ -128,8 +131,8 @@ size_t InitOpenCLGpu(int index, cl_context opencl_ctx, GpuContext* ctx, const ch
     getDeviceName(ctx->DeviceID, buf, sizeof(buf));
     ctx->computeUnits = getDeviceMaxComputeUnits(ctx->DeviceID);
 
-    LOG_INFO(config->isColors() ? "\x1B[01;37m#%d\x1B[0m, GPU \x1B[01;37m#%zu\x1B[0m \x1B[01;32m%s\x1B[0m, intensity: \x1B[01;37m%zu\x1B[0m (%zu/%zu), cu: \x1B[01;37m%d"  : "#%d, GPU #%zu (%s), intensity: %zu (%zu/%zu), cu: %d",
-        index, ctx->deviceIdx, buf, ctx->rawIntensity, ctx->workSize, MaximumWorkSize, ctx->computeUnits);
+    LOG_INFO(config->isColors() ? "\x1B[01;37m#%d\x1B[0m, GPU \x1B[01;37m#%zu\x1B[0m \x1B[01;32m%s\x1B[0m, intensity: \x1B[01;37m%zu\x1B[0m (%zu/%zu), unroll: \x1B[01;37m%d, cu: \x1B[01;37m%d"  : "#%d, GPU #%zu (%s), intensity: %zu (%zu/%zu), unroll: %d, cu: %d",
+        index, ctx->deviceIdx, buf, ctx->rawIntensity, ctx->workSize, MaximumWorkSize, ctx->unrollFactor, ctx->computeUnits);
 
     ctx->CommandQueues = OclLib::createCommandQueue(opencl_ctx, ctx->DeviceID, &ret);
     if (ret != CL_SUCCESS) {
@@ -195,8 +198,8 @@ size_t InitOpenCLGpu(int index, cl_context opencl_ctx, GpuContext* ctx, const ch
         return OCL_ERR_API;
     }
 
-    const char *KernelNames[] = { "cn0", "cn1", "cn2", "Blake", "Groestl", "JH", "Skein", "cn1_monero", "cn1_msr", "cn1_xao", "cn1_tube"};
-    for (int i = 0; i < 11; ++i) {
+    const char *KernelNames[] = { "cn0", "cn1", "cn2", "Blake", "Groestl", "JH", "Skein", "cn1_monero", "cn1_msr", "cn1_xao", "cn1_tube", "cn1_v2_monero"};
+    for (int i = 0; i < 12; ++i) {
         ctx->Kernels[i] = OclLib::createKernel(ctx->Program, KernelNames[i], &ret);
         if (ret != CL_SUCCESS) {
             return OCL_ERR_API;
@@ -401,13 +404,17 @@ size_t InitOpenCL(GpuContext* ctx, size_t num_gpus, xmrig::Config *config)
     const char *wolfSkeinCL =
             #include "./opencl/wolf-skein.cl"
     ;
+    const char *fastIntMathV2CL =
+        #include "./opencl/fast_int_math_v2.cl"
+    ;
 
     std::string source_code(cryptonightCL);
-    source_code = std::regex_replace(source_code, std::regex("XMRIG_INCLUDE_WOLF_AES"),   wolfAesCL);
-    source_code = std::regex_replace(source_code, std::regex("XMRIG_INCLUDE_WOLF_SKEIN"), wolfSkeinCL);
-    source_code = std::regex_replace(source_code, std::regex("XMRIG_INCLUDE_JH"),         jhCL);
-    source_code = std::regex_replace(source_code, std::regex("XMRIG_INCLUDE_BLAKE256"),   blake256CL);
-    source_code = std::regex_replace(source_code, std::regex("XMRIG_INCLUDE_GROESTL256"), groestl256CL);
+    source_code = std::regex_replace(source_code, std::regex("XMRIG_INCLUDE_WOLF_AES"),         wolfAesCL);
+    source_code = std::regex_replace(source_code, std::regex("XMRIG_INCLUDE_WOLF_SKEIN"),       wolfSkeinCL);
+    source_code = std::regex_replace(source_code, std::regex("XMRIG_INCLUDE_JH"),               jhCL);
+    source_code = std::regex_replace(source_code, std::regex("XMRIG_INCLUDE_BLAKE256"),         blake256CL);
+    source_code = std::regex_replace(source_code, std::regex("XMRIG_INCLUDE_GROESTL256"),       groestl256CL);
+    source_code = std::regex_replace(source_code, std::regex("XMRIG_INCLUDE_FAST_INT_MATH_V2"), fastIntMathV2CL);
 
     for (size_t i = 0; i < num_gpus; ++i) {
         if (ctx[i].stridedIndex == 2 && (ctx[i].rawIntensity % ctx[i].workSize) != 0) {

--- a/src/amd/opencl/cryptonight.cl
+++ b/src/amd/opencl/cryptonight.cl
@@ -88,6 +88,8 @@ XMRIG_INCLUDE_JH
 XMRIG_INCLUDE_BLAKE256
 //#include "opencl/groestl256.cl"
 XMRIG_INCLUDE_GROESTL256
+//#include "fast_int_math_v2.cl"
+XMRIG_INCLUDE_FAST_INT_MATH_V2
 
 
 #define VARIANT_0    0  // Original CryptoNight or CryptoNight-Heavy
@@ -614,6 +616,116 @@ __kernel void cn1_monero(__global uint4 *Scratchpad, __global ulong *states, ulo
     mem_fence(CLK_GLOBAL_MEM_FENCE);
 }
 
+
+)==="
+R"===(
+
+__attribute__((reqd_work_group_size(WORKSIZE, 1, 1)))
+__kernel void cn1_v2_monero(__global uint4 *Scratchpad, __global ulong *states, ulong Threads, uint variant, __global ulong *input)
+{
+	ulong a[2], b[4];
+	__local uint AES0[256], AES1[256], AES2[256], AES3[256], RCP[256];
+	
+	const ulong gIdx = getIdx();
+
+	for(int i = get_local_id(0); i < 256; i += WORKSIZE)
+	{
+		const uint tmp = AES0_C[i];
+		AES0[i] = tmp;
+		AES1[i] = rotate(tmp, 8U);
+		AES2[i] = rotate(tmp, 16U);
+		AES3[i] = rotate(tmp, 24U);
+		RCP[i] = RCP_C[i];
+	}
+
+	barrier(CLK_LOCAL_MEM_FENCE);
+
+#	if (COMP_MODE == 1)
+	// do not use early return here
+	if (gIdx < Threads)
+#	endif
+	{
+		Scratchpad += gIdx * (MEMORY >> 4);
+		states += 25 * gIdx;
+	}
+	
+	a[0] = states[0] ^ states[4];
+	a[1] = states[1] ^ states[5];
+
+	b[0] = states[2] ^ states[6];
+	b[1] = states[3] ^ states[7];
+	b[2] = states[8] ^ states[10];
+	b[3] = states[9] ^ states[11];
+	
+	ulong2 bx0 = ((ulong2 *)b)[0];
+	ulong2 bx1 = ((ulong2 *)b)[1];
+	
+	mem_fence(CLK_LOCAL_MEM_FENCE);
+
+	uint2 division_result = as_uint2(states[12]);
+	uint sqrt_result = as_uint2(states[13]).s0;
+	
+#define SCRATCHPAD_CHUNK(N) (*(__global uint4*)((__global uchar*)(Scratchpad) + (idx ^ (N << 4))))
+
+#   if (COMP_MODE == 1)
+    // do not use early return here
+    if (gIdx < Threads)
+#   endif
+    {
+	#pragma unroll UNROLL_FACTOR
+	for(int i = 0; i < ITERATIONS; ++i)
+	{
+		ulong idx = a[0] & MASK;
+		uint4 c = SCRATCHPAD_CHUNK(0);
+		c = AES_Round(AES0, AES1, AES2, AES3, c, ((uint4 *)a)[0]);
+
+		{
+			const ulong2 chunk1 = as_ulong2(SCRATCHPAD_CHUNK(1));
+			const ulong2 chunk2 = as_ulong2(SCRATCHPAD_CHUNK(2));
+			const ulong2 chunk3 = as_ulong2(SCRATCHPAD_CHUNK(3));
+
+			SCRATCHPAD_CHUNK(1) = as_uint4(chunk3 + bx1);
+			SCRATCHPAD_CHUNK(2) = as_uint4(chunk1 + bx0);
+			SCRATCHPAD_CHUNK(3) = as_uint4(chunk2 + ((ulong2 *)a)[0]);
+		}
+
+		SCRATCHPAD_CHUNK(0) = as_uint4(bx0) ^ c;
+
+		idx = as_ulong2(c).s0 & MASK;
+		uint4 tmp = SCRATCHPAD_CHUNK(0);
+
+		{
+			tmp.s0 ^= division_result.s0;
+			tmp.s1 ^= division_result.s1 ^ sqrt_result;
+
+			division_result = fast_div_v2((__local uchar *) RCP, as_ulong2(c).s1, (c.s0 + (sqrt_result << 1)) | 0x80000001UL);
+			sqrt_result = fast_sqrt_v2(as_ulong2(c).s0 + as_ulong(division_result));
+		}
+
+		{
+			const ulong2 chunk1 = as_ulong2(SCRATCHPAD_CHUNK(1));
+			const ulong2 chunk2 = as_ulong2(SCRATCHPAD_CHUNK(2));
+			const ulong2 chunk3 = as_ulong2(SCRATCHPAD_CHUNK(3));
+
+			SCRATCHPAD_CHUNK(1) = as_uint4(chunk3 + bx1);
+			SCRATCHPAD_CHUNK(2) = as_uint4(chunk1 + bx0);
+			SCRATCHPAD_CHUNK(3) = as_uint4(chunk2 + ((ulong2 *)a)[0]);
+		}
+
+		a[1] += as_ulong2(c).s0 * as_ulong2(tmp).s0;
+		a[0] += mul_hi(as_ulong2(c).s0, as_ulong2(tmp).s0);
+
+		SCRATCHPAD_CHUNK(0) = ((uint4 *)a)[0];
+
+		((uint4 *)a)[0] ^= tmp;
+		bx1 = bx0;
+		bx0 = as_ulong2(c);
+	}
+	
+#undef SCRATCHPAD_CHUNK
+    }
+    mem_fence(CLK_GLOBAL_MEM_FENCE);
+}
 
 )==="
 R"===(

--- a/src/amd/opencl/fast_int_math_v2.cl
+++ b/src/amd/opencl/fast_int_math_v2.cl
@@ -1,0 +1,111 @@
+R"===(
+#ifndef FAST_INT_MATH_CL
+#define FAST_INT_MATH_CL
+
+static const __constant uint RCP_C[256] =
+{
+	0xfe01be73u,0xfd07ff01u,0xfa118c5au,0xf924fb13u,0xf630cddbu,0xf558f73cu,0xf25f2934u,0xf1a3f37bu,
+	0xee9c4562u,0xee02efd0u,0xeae7ced5u,0xea76ec3au,0xe7417330u,0xe6ffe8b8u,0xe3a8e217u,0xe39be54au,
+	0xe01dcd03u,0xe04ae1f0u,0xdc9fea3bu,0xdd0bdea8u,0xd92eef38u,0xd9dedb73u,0xd5ca9626u,0xd6c3d84fu,
+	0xd27299dcu,0xd3b9d53cu,0xcf26b659u,0xd0bfd23au,0xcbe6ab09u,0xcdd5cf48u,0xc8b23886u,0xcafacc65u,
+	0xc58920e5u,0xc82ec992u,0xc26b283eu,0xc572c6ceu,0xbf5813d7u,0xc2c3c419u,0xbc4facdbu,0xc023c171u,
+	0xb951b9f6u,0xbd8fbed7u,0xb65e05c8u,0xbb09bc4bu,0xb3745d97u,0xb890b9cbu,0xb0948d04u,0xb624b758u,
+	0xadbe61e8u,0xb3c3b4f2u,0xaaf1ae2au,0xb16eb297u,0xa82e412eu,0xaf25b048u,0xa573ec98u,0xace7ae05u,
+	0xa2c28519u,0xaab4abcdu,0xa019df1cu,0xa88ca99fu,0x9d79cf91u,0xa66ea77cu,0x9ae22df8u,0xa45ba563u,
+	0x9852d0ceu,0xa251a354u,0x95cb912eu,0xa050a14fu,0x934c48d6u,0x9e5a9f54u,0x90d4d228u,0x9c6c9d62u,
+	0x8e650939u,0x9a879b79u,0x8bfccaf5u,0x98ac9998u,0x899bf212u,0x96d897c1u,0x87425eedu,0x950d95f2u,
+	0x84efefd3u,0x934a942bu,0x82a48450u,0x918f926cu,0x805ffcb4u,0x8fdc90b5u,0x7e223ab7u,0x8e308f05u,
+	0x7beb1f71u,0x8c8c8d5du,0x79ba8ce2u,0x8aef8bbdu,0x7790683eu,0x89598a23u,0x756c9343u,0x87ca8891u,
+	0x734ef468u,0x86428705u,0x71376efbu,0x84c18581u,0x6f25e9ebu,0x83458402u,0x6d1a4b34u,0x81d0828au,
+	0x6b147a52u,0x80628118u,0x69145cfbu,0x7ef97fadu,0x6719dd39u,0x7d967e47u,0x6524e2abu,0x7c397ce7u,
+	0x6335561bu,0x7ae27b8du,0x614b21eau,0x79907a38u,0x5f662f10u,0x784478e9u,0x5d8667dfu,0x76fd77a0u,
+	0x5babb887u,0x75bb765bu,0x59d60b2eu,0x747e751cu,0x58054d25u,0x734673e1u,0x5639688fu,0x721372acu,
+	0x54724c2du,0x70e5717bu,0x52afe29cu,0x6fbb7050u,0x50f21c05u,0x6e966f28u,0x4f38e412u,0x6d766e06u,
+	0x4d842a91u,0x6c5a6ce7u,0x4bd3dcd0u,0x6b426bcdu,0x4a27e96au,0x6a2e6ab8u,0x4880415eu,0x691f69a6u,
+	0x46dcd25du,0x68136899u,0x453d8df4u,0x670c678fu,0x43a262a5u,0x6608668au,0x420b42d6u,0x65096588u,
+	0x40781dd3u,0x640d648au,0x3ee8e49au,0x63146390u,0x3d5d8a11u,0x621f6299u,0x3bd5fee0u,0x612e61a6u,
+	0x3a523496u,0x604060b7u,0x38d21e75u,0x5f565fcbu,0x3755aec4u,0x5e6f5ee2u,0x35dcd78fu,0x5d8b5dfdu,
+	0x34678d72u,0x5cab5d1au,0x32f5c17cu,0x5bcd5c3bu,0x318767f1u,0x5af35b60u,0x301c7511u,0x5a1b5a87u,
+	0x2eb4dccau,0x594759b1u,0x2d50935cu,0x587658deu,0x2bef8bfau,0x57a7580eu,0x2a91bc5cu,0x56db5741u,
+	0x2937198fu,0x56125676u,0x27df970eu,0x554c55afu,0x268b2b78u,0x548854eau,0x2539cba1u,0x53c75428u,
+	0x23eb6d84u,0x53095368u,0x22a00644u,0x524d52abu,0x21578cd3u,0x519451f0u,0x2011f5f9u,0x50dd5138u,
+	0x1ecf388eu,0x50285082u,0x1d8f4b53u,0x4f764fcfu,0x1c5224abu,0x4ec64f1eu,0x1b17bb87u,0x4e184e6fu,
+	0x19e0073fu,0x4d6d4dc2u,0x18aafe0au,0x4cc44d18u,0x177896f3u,0x4c1c4c70u,0x1648cb16u,0x4b784bcau,
+	0x151b9051u,0x4ad54b26u,0x13f0deeau,0x4a344a84u,0x12c8aef3u,0x499549e4u,0x11a2f829u,0x48f84946u,
+	0x107fb1ffu,0x485d48abu,0xf5ed5f0u,0x47c44811u,0xe405bc1u,0x472d4779u,0xd243bdau,0x469846e3u,
+	0xc0a6fa1u,0x4605464eu,0xaf2edf2u,0x457345bcu,0x9ddb163u,0x44e3452bu,0x8cab264u,0x4455449cu,
+	0x7b9e9d5u,0x43c9440fu,0x6ab5173u,0x433e4383u,0x59ee141u,0x42b542fau,0x49494c7u,0x422e4271u,
+	0x38c62ffu,0x41a841ebu,0x286478bu,0x41244166u,0x1823b84u,0x40a140e2u,0x803883u,0x401C4060u,
+};
+
+inline uint get_reciprocal(const __local uchar *RCP, uint a)
+{
+	const uint index1 = (a & 0x7F000000U) >> 21;
+	const int index2 = (int)((a >> 8) & 0xFFFFU) - 32768;
+
+	const uint r1 = *(const __local uint*)(RCP + index1);
+
+	uint r2_0 = *(const __local uint*)(RCP + index1 + 4);
+	if (index2 > 0) r2_0 >>= 16;
+	const int r2 = r2_0 & 0xFFFFU;
+
+	const uint r = r1 - (uint)(mul24(r2, index2) >> 6);
+
+	const ulong lo0 = (ulong)(r) * a;
+	ulong lo = lo0 + ((ulong)(a) << 32);
+
+	a >>= 1;
+	const bool b = (a >= lo) || (lo >= lo0);
+	lo = a - lo;
+
+	const ulong k = mul_hi(as_uint2(lo).s0, r) + ((ulong)(r) * as_uint2(lo).s1) + lo;
+	return as_uint2(k).s1 + (b ? r : 0);
+}
+
+inline uint2 fast_div_v2(const __local uchar *RCP, ulong a, uint b)
+{
+	const uint r = get_reciprocal(RCP, b);
+	const ulong k = mul_hi(as_uint2(a).s0, r) + ((ulong)(r) * as_uint2(a).s1) + a;
+
+	ulong q;
+	((uint*)&q)[0] = as_uint2(k).s1;;
+	((uint*)&q)[1] = (k < a) ? 1 : 0;
+
+	const long tmp = a - q * b;
+	const bool overshoot = (tmp < 0);
+	const bool undershoot = (tmp >= b);
+
+	return (uint2)(
+		as_uint2(q).s0 + (undershoot ? 1U : 0U) - (overshoot ? 1U : 0U),
+		as_uint2(tmp).s0 + (overshoot ? b : 0U) - (undershoot ? b : 0U)
+	);
+}
+
+inline uint fast_sqrt_v2(const ulong n1)
+{
+	float x = as_float((as_uint2(n1).s1 >> 9) + ((64U + 127U) << 23));
+
+	float x1 = native_rsqrt(x);
+	x = native_sqrt(x);
+
+	// The following line does x1 *= 4294967296.0f;
+	x1 = as_float(as_uint(x1) + (32U << 23));
+
+	const uint x0 = as_uint(x) - (158U << 23);
+	const long delta0 = n1 - (((long)(x0) * x0) << 18);
+	const float delta = convert_float_rte(as_int2(delta0).s1) * x1;
+
+	uint result = (x0 << 10) + convert_int_rte(delta);
+	const uint s = result >> 1;
+	const uint b = result & 1;
+
+	const ulong x2 = (ulong)(s) * (s + b) + ((ulong)(result) << 32) - n1;
+	if ((long)(x2 + b) > 0) --result;
+	if ((long)(x2 + 0x100000000UL + s) < 0) ++result;
+
+	return result;
+}
+
+#endif
+
+)==="

--- a/src/workers/OclThread.h
+++ b/src/workers/OclThread.h
@@ -34,7 +34,7 @@ class OclThread : public xmrig::IThread
 public:
     OclThread();
     OclThread(const rapidjson::Value &object);
-    OclThread(size_t index, size_t intensity, size_t worksize, int64_t affinity = -1);
+    OclThread(size_t index, size_t intensity, size_t worksize, int64_t affinity = -1, int unrollFactor = 8);
     ~OclThread();
 
     inline bool isCompMode() const  { return m_compMode; }
@@ -42,6 +42,7 @@ public:
     inline int stridedIndex() const { return m_stridedIndex; }
     inline size_t intensity() const { return m_intensity; }
     inline size_t worksize() const  { return m_worksize; }
+    inline int unrollFactor() const { return m_unrollFactor; }
 
     inline void setAffinity(int64_t affinity)  { m_affinity = affinity; }
     inline void setIndex(size_t index)         { m_index = index; }
@@ -57,6 +58,7 @@ public:
 
     void setMemChunk(int memChunk);
     void setStridedIndex(int stridedIndex);
+    void setUnrollFactor(int unrollFactor);
 
 protected:
 #   ifndef XMRIG_NO_API
@@ -69,6 +71,7 @@ private:
     bool m_compMode;
     int m_memChunk;
     int m_stridedIndex;
+    int m_unrollFactor;
     int64_t m_affinity;
     size_t m_index;
     size_t m_intensity;

--- a/src/workers/Workers.cpp
+++ b/src/workers/Workers.cpp
@@ -190,7 +190,7 @@ bool Workers::start(xmrig::Controller *controller)
 
     for (size_t i = 0; i < m_threadsCount; ++i) {
         const OclThread *thread = static_cast<OclThread *>(threads[i]);
-        contexts[i] = GpuContext(thread->index(), thread->intensity(), thread->worksize(), thread->stridedIndex(), thread->memChunk(), thread->isCompMode());
+        contexts[i] = GpuContext(thread->index(), thread->intensity(), thread->worksize(), thread->stridedIndex(), thread->memChunk(), thread->isCompMode(), thread->unrollFactor());
     }
 
     if (InitOpenCL(contexts.data(), m_threadsCount, controller->config()) != 0) {


### PR DESCRIPTION
- Added new per-thread parameter "unroll_factor" which can be set to 1, 2, 4, 8, 16, 32 or 64, default is 8.
- CNv2 OpenCL code is in a separate kernel because it uses 1KB more local memory which can hurt other variants performance
- Fixed a bug with "comp_mode"=1 no matter what was set in config.json

Sample thread setting for Radeon RX 560 which gave me the best performance:

    "threads": [
        {
            "index": 0,
            "intensity": 1024,
            "worksize": 32,
            "strided_index": 0,
            "mem_chunk": 2,
            "unroll_factor": 16,
            "comp_mode": false,
            "affine_to_cpu": false
        }
    ],

Performance was the same as in my previous GPU tests.