### PR TITLE
Compatibility with xmr-stak

### DIFF
--- a/src/workers/Hashrate.cpp
+++ b/src/workers/Hashrate.cpp
@@ -193,4 +193,5 @@ const char *Hashrate::format(double h, char *buf, size_t size)
 void Hashrate::onReport(uv_timer_t *handle)
 {
     static_cast<Hashrate*>(handle->data)->print();
+    Workers::printHashrate(true);
 }


### PR DESCRIPTION
I'm porting some of my monitoring scripts from xmr-stak to xmrig. Former miner reports GPU's statistics at each "print-time" interval. Without this information it's not possible to tell hashrate of individual card (I need it for statistic) and monitor its availability. Probably, it should be made configurable by some parameter in config.json